### PR TITLE
Remove uses of old Readdir function and helpers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,9 +134,6 @@ issues:
     - text: "Errors unhandled"
       linters:
         - gosec
-    - text: "unwrapped: sig: func github.com/kopia/kopia/fs.ReaddirToIterate"
-      linters:
-        - wrapcheck
-    - text: "unwrapped: sig: func github.com/kopia/kopia/fs.IterateEntriesToReaddir"
+    - text: "unwrapped: sig: func github.com/kopia/kopia/fs.GetAllEntries"
       linters:
         - wrapcheck

--- a/cli/command_ls.go
+++ b/cli/command_ls.go
@@ -55,11 +55,7 @@ func (c *commandList) run(ctx context.Context, rep repo.Repository) error {
 
 func (c *commandList) listDirectory(ctx context.Context, d fs.Directory, prefix, indent string) error {
 	if err := d.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
-		if err2 := c.printDirectoryEntry(innerCtx, e, prefix, indent); err2 != nil {
-			return err2
-		}
-
-		return nil
+		return c.printDirectoryEntry(innerCtx, e, prefix, indent)
 	}); err != nil {
 		return err // nolint:wrapcheck
 	}

--- a/cli/command_ls.go
+++ b/cli/command_ls.go
@@ -54,15 +54,14 @@ func (c *commandList) run(ctx context.Context, rep repo.Repository) error {
 }
 
 func (c *commandList) listDirectory(ctx context.Context, d fs.Directory, prefix, indent string) error {
-	entries, err := d.Readdir(ctx)
-	if err != nil {
-		return errors.Wrap(err, "error reading directory")
-	}
-
-	for _, e := range entries {
-		if err := c.printDirectoryEntry(ctx, e, prefix, indent); err != nil {
-			return errors.Wrap(err, "unable to print directory entry")
+	if err := d.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
+		if err2 := c.printDirectoryEntry(innerCtx, e, prefix, indent); err2 != nil {
+			return err2
 		}
+
+		return nil
+	}); err != nil {
+		return err // nolint:wrapcheck
 	}
 
 	if dws, ok := d.(fs.DirectoryWithSummary); ok && c.errorSummary {

--- a/cli/command_snapshot_create.go
+++ b/cli/command_snapshot_create.go
@@ -273,7 +273,7 @@ func (c *commandSnapshotCreate) snapshotSingleSource(ctx context.Context, rep re
 	if c.snapshotCreateStdinFileName != "" {
 		// stdin source will be snapshotted using a virtual static root directory with a single streaming file entry
 		// Create a new static directory with the given name and add a streaming file entry with os.Stdin reader
-		fsEntry = virtualfs.NewStaticDirectory(sourceInfo.Path, fs.Entries{
+		fsEntry = virtualfs.NewStaticDirectory(sourceInfo.Path, []fs.Entry{
 			virtualfs.StreamingFileFromReader(c.snapshotCreateStdinFileName, os.Stdin),
 		})
 		setManual = true

--- a/fs/cachefs/cache.go
+++ b/fs/cachefs/cache.go
@@ -94,17 +94,7 @@ func (c *Cache) IterateEntries(ctx context.Context, d fs.Directory, w EntryWrapp
 			cacheID,
 			dirCacheExpiration,
 			func(innerCtx context.Context) (fs.Entries, error) {
-				result := fs.Entries(nil)
-				err2 := d.IterateEntries(innerCtx, func(callbackCtx context.Context, e fs.Entry) error {
-					result = append(result, e)
-					return nil
-				})
-
-				if err2 != nil {
-					return nil, err2 // nolint:wrapcheck
-				}
-
-				return result, nil
+				return fs.GetAllEntries(innerCtx, d)
 			},
 			w,
 		)

--- a/fs/cachefs/cache_test.go
+++ b/fs/cachefs/cache_test.go
@@ -20,7 +20,7 @@ import (
 const expirationTime = 10 * time.Hour
 
 type cacheSource struct {
-	data        map[string]fs.Entries
+	data        map[string][]fs.Entry
 	callCounter map[string]int
 }
 
@@ -28,8 +28,8 @@ func identityWrapper(e fs.Entry) fs.Entry {
 	return e
 }
 
-func (cs *cacheSource) get(id string) func(ctx context.Context) (fs.Entries, error) {
-	return func(context.Context) (fs.Entries, error) {
+func (cs *cacheSource) get(id string) func(ctx context.Context) ([]fs.Entry, error) {
+	return func(context.Context) ([]fs.Entry, error) {
 		cs.callCounter[id]++
 
 		d, ok := cs.data[id]
@@ -42,7 +42,7 @@ func (cs *cacheSource) get(id string) func(ctx context.Context) (fs.Entries, err
 }
 
 func (cs *cacheSource) setEntryCount(id string, cnt int) {
-	var fakeEntries fs.Entries
+	var fakeEntries []fs.Entry
 
 	var fakeEntry fs.Entry
 
@@ -56,7 +56,7 @@ func (cs *cacheSource) setEntryCount(id string, cnt int) {
 
 func newCacheSource() *cacheSource {
 	return &cacheSource{
-		data:        make(map[string]fs.Entries),
+		data:        make(map[string][]fs.Entry),
 		callCounter: make(map[string]int),
 	}
 }

--- a/fs/cachefs/cachefs.go
+++ b/fs/cachefs/cachefs.go
@@ -9,7 +9,6 @@ import (
 
 // DirectoryCacher reads and potentially caches directory entries for a given directory.
 type DirectoryCacher interface {
-	Readdir(ctx context.Context, d fs.Directory, w EntryWrapper) (fs.Entries, error)
 	IterateEntries(ctx context.Context, d fs.Directory, w EntryWrapper, callback func(context.Context, fs.Entry) error) error
 }
 
@@ -43,19 +42,6 @@ func (d *directory) IterateEntries(ctx context.Context, callback func(context.Co
 	)
 
 	return err // nolint:wrapcheck
-}
-
-func (d *directory) Readdir(ctx context.Context) (fs.Entries, error) {
-	entries, err := d.ctx.cacher.Readdir(ctx, d.Directory, func(e fs.Entry) fs.Entry {
-		return wrapWithContext(e, d.ctx)
-	})
-	if err != nil {
-		// nolint:wrapcheck
-		return entries, err
-	}
-
-	// nolint:wrapcheck
-	return entries, err
 }
 
 type file struct {

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -33,9 +33,6 @@ type DeviceInfo struct {
 	Rdev uint64 `json:"rdev"`
 }
 
-// Entries is a list of entries sorted by name.
-type Entries []Entry
-
 // Reader allows reading from a file and retrieving its up-to-date file info.
 type Reader interface {
 	io.ReadCloser
@@ -76,8 +73,8 @@ type ErrorEntry interface {
 }
 
 // GetAllEntries uses IterateEntries to return all entries in a Directory.
-func GetAllEntries(ctx context.Context, d Directory) (fs.Entries, error) {
-  var entries fs.Entries(nil)
+func GetAllEntries(ctx context.Context, d Directory) ([]Entry, error) {
+	entries := []Entry{}
 
 	err := d.IterateEntries(ctx, func(ctx context.Context, e Entry) error {
 		entries = append(entries, e)
@@ -160,74 +157,25 @@ type Symlink interface {
 	Readlink(ctx context.Context) (string, error)
 }
 
-// FindByName returns an entry with a given name, or nil if not found.
-func (e Entries) FindByName(n string) Entry {
+// FindByName returns an entry with a given name, or nil if not found. Assumes
+// the given slice of fs.Entry is sorted.
+func FindByName(entries []Entry, n string) Entry {
 	i := sort.Search(
-		len(e),
+		len(entries),
 		func(i int) bool {
-			return e[i].Name() >= n
+			return entries[i].Name() >= n
 		},
 	)
-	if i < len(e) && e[i].Name() == n {
-		return e[i]
+	if i < len(entries) && entries[i].Name() == n {
+		return entries[i]
 	}
 
 	return nil
 }
 
-// Update returns a copy of Entries with the provided entry included, by either replacing
-// existing entry with the same name or inserted in the appropriate place to maintain sorted order.
-func (e Entries) Update(newEntry Entry) Entries {
-	name := newEntry.Name()
-	pos := sort.Search(len(e), func(i int) bool {
-		return e[i].Name() >= name
-	})
-
-	// append at the end
-	if pos >= len(e) {
-		return append(append(Entries(nil), e...), newEntry)
-	}
-
-	if e[pos].Name() == name {
-		if pos > 0 {
-			return append(append(append(Entries(nil), e[0:pos]...), newEntry), e[pos+1:]...)
-		}
-
-		return append(append(Entries(nil), newEntry), e[pos+1:]...)
-	}
-
-	if pos > 0 {
-		return append(append(append(Entries(nil), e[0:pos]...), newEntry), e[pos:]...)
-	}
-
-	return append(append(Entries(nil), newEntry), e[pos:]...)
-}
-
-// Remove returns a copy of Entries with the provided entry removed, while maintaining sorted order.
-func (e Entries) Remove(name string) Entries {
-	pos := sort.Search(len(e), func(i int) bool {
-		return e[i].Name() >= name
-	})
-
-	// not found
-	if pos >= len(e) {
-		return e
-	}
-
-	if e[pos].Name() != name {
-		return e
-	}
-
-	if pos > 0 {
-		return append(append(Entries(nil), e[0:pos]...), e[pos+1:]...)
-	}
-
-	return append(Entries(nil), e[pos+1:]...)
-}
-
 // Sort sorts the entries by name.
-func (e Entries) Sort() {
-	sort.Slice(e, func(i, j int) bool {
-		return e[i].Name() < e[j].Name()
+func Sort(entries []Entry) {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
 	})
 }

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -109,6 +109,23 @@ func IterateEntriesToReaddir(ctx context.Context, d Directory) (Entries, error) 
 	return entries, err // nolint:wrapcheck
 }
 
+// IterateEntriesAndFindChild iterates through entries from a directory and returns one by name.
+// This is a convenience function that may be helpful in implementations of Directory.Child().
+func IterateEntriesAndFindChild(ctx context.Context, d Directory, name string) (Entry, error) {
+	var result Entry
+
+	if err := d.IterateEntries(ctx, func(c context.Context, e Entry) error {
+		if result == nil && e.Name() == name {
+			result = e
+		}
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "error reading directory")
+	}
+
+	return result, nil
+}
+
 // ReadDirAndFindChild reads all entries from a directory and returns one by name.
 // This is a convenience function that may be helpful in implementations of Directory.Child().
 func ReadDirAndFindChild(ctx context.Context, d Directory, name string) (Entry, error) {

--- a/fs/entry_test.go
+++ b/fs/entry_test.go
@@ -18,40 +18,40 @@ func (e testEntry) Name() string {
 }
 
 func TestEntriesFindByName(t *testing.T) {
-	entries := Entries{
+	entries := []Entry{
 		testEntry{n: "aa", value: 3},
 		testEntry{n: "cc", value: 5},
 		testEntry{n: "ee", value: 6},
 	}
 
 	want := testEntry{n: "aa", value: 3}
-	if got := entries.FindByName("aa"); got != want {
+	if got := FindByName(entries, "aa"); got != want {
 		t.Errorf("a")
 	}
 
-	if got := entries.FindByName("aa0"); got != nil {
+	if got := FindByName(entries, "aa0"); got != nil {
 		t.Errorf("unexpected result when looking for non-existent: %v", got)
 	}
 
-	if got := entries.FindByName("dd"); got != nil {
+	if got := FindByName(entries, "dd"); got != nil {
 		t.Errorf("unexpected result when looking for non-existent: %v", got)
 	}
 
-	if got := entries.FindByName("ff"); got != nil {
+	if got := FindByName(entries, "ff"); got != nil {
 		t.Errorf("unexpected result when looking for non-existent: %v", got)
 	}
 }
 
 func TestEntriesSort(t *testing.T) {
-	entries := Entries{
+	entries := []Entry{
 		testEntry{n: "cc"},
 		testEntry{n: "bb"},
 		testEntry{n: "aa"},
 	}
 
-	entries.Sort()
+	Sort(entries)
 
-	want := Entries{
+	want := []Entry{
 		testEntry{n: "aa"},
 		testEntry{n: "bb"},
 		testEntry{n: "cc"},
@@ -59,225 +59,5 @@ func TestEntriesSort(t *testing.T) {
 
 	if diff := pretty.Compare(entries, want); diff != "" {
 		t.Errorf("unexpected output diff (-got, +want): %v", diff)
-	}
-}
-
-func TestEntriesUpdate(t *testing.T) {
-	cases := []struct {
-		desc         string
-		base         Entries
-		updatedEntry Entry
-		want         Entries
-	}{
-		{
-			desc: "update existing - first",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			updatedEntry: testEntry{n: "aa", value: 3},
-			want: Entries{
-				testEntry{n: "aa", value: 3},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "update existing in the middle",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			updatedEntry: testEntry{n: "bb", value: 3},
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb", value: 3},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "update existing - last",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			updatedEntry: testEntry{n: "cc", value: 3},
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc", value: 3},
-			},
-		},
-		{
-			desc: "insert before first",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			updatedEntry: testEntry{n: "00", value: 3},
-			want: Entries{
-				testEntry{n: "00", value: 3},
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "insert between 2 existing",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "cc"},
-				testEntry{n: "dd"},
-			},
-			updatedEntry: testEntry{n: "bb", value: 3},
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb", value: 3},
-				testEntry{n: "cc"},
-				testEntry{n: "dd"},
-			},
-		},
-		{
-			desc: "insert after last first",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			updatedEntry: testEntry{n: "dd", value: 3},
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-				testEntry{n: "dd", value: 3},
-			},
-		},
-		{
-			desc:         "append to empty",
-			base:         Entries{},
-			updatedEntry: testEntry{n: "dd", value: 3},
-			want: Entries{
-				testEntry{n: "dd", value: 3},
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Logf("starting %q", tc.desc)
-		updated := tc.base.Update(tc.updatedEntry)
-
-		if diff := pretty.Compare(updated, tc.want); diff != "" {
-			t.Errorf("unexpected output for %q diff (-got, +want): %v", tc.desc, diff)
-		}
-	}
-}
-
-func TestEntriesRemove(t *testing.T) {
-	cases := []struct {
-		desc         string
-		base         Entries
-		removedEntry string
-		want         Entries
-	}{
-		{
-			desc: "remove existing - first",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			removedEntry: "aa",
-			want: Entries{
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "remove existing in the middle",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			removedEntry: "bb",
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "remove existing - last",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			removedEntry: "cc",
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-			},
-		},
-		{
-			desc: "non-existent before first",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			removedEntry: "00",
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc: "non-existent in the middle",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "dd"},
-			},
-			removedEntry: "cc",
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "dd"},
-			},
-		},
-		{
-			desc: "non-existent after last",
-			base: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-			removedEntry: "dd",
-			want: Entries{
-				testEntry{n: "aa"},
-				testEntry{n: "bb"},
-				testEntry{n: "cc"},
-			},
-		},
-		{
-			desc:         "empty",
-			base:         Entries{},
-			removedEntry: "zz",
-			want:         Entries{},
-		},
-	}
-
-	for _, tc := range cases {
-		t.Logf("starting %q", tc.desc)
-		updated := tc.base.Remove(tc.removedEntry)
-
-		if diff := pretty.Compare(updated, tc.want); diff != "" {
-			t.Errorf("unexpected output for %q diff (-got, +want): %v", tc.desc, diff)
-		}
 	}
 }

--- a/fs/ignorefs/ignorefs.go
+++ b/fs/ignorefs/ignorefs.go
@@ -210,10 +210,6 @@ func (d *ignoreDirectory) Child(ctx context.Context, name string) (fs.Entry, err
 	return nil, fs.ErrEntryNotFound
 }
 
-func (d *ignoreDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return fs.IterateEntriesToReaddir(ctx, d)
-}
-
 func (d *ignoreDirectory) buildContext(ctx context.Context) (*ignoreContext, error) {
 	effectiveDotIgnoreFiles := d.parentContext.dotIgnoreFiles
 

--- a/fs/ignorefs/ignorefs_test.go
+++ b/fs/ignorefs/ignorefs_test.go
@@ -2,6 +2,7 @@ package ignorefs_test
 
 import (
 	"bytes"
+	"context"
 	"sort"
 	"testing"
 
@@ -548,12 +549,7 @@ func walkTree(t *testing.T, dir fs.Directory) []string {
 	walk = func(path string, d fs.Directory) error {
 		output = append(output, path+"/")
 
-		entries, err := d.Readdir(testlogging.Context(t))
-		if err != nil {
-			return err
-		}
-
-		for _, e := range entries {
+		return d.IterateEntries(testlogging.Context(t), func(innerCtx context.Context, e fs.Entry) error {
 			relPath := path + "/" + e.Name()
 
 			if subdir, ok := e.(fs.Directory); ok {
@@ -563,9 +559,9 @@ func walkTree(t *testing.T, dir fs.Directory) []string {
 			} else {
 				output = append(output, relPath)
 			}
-		}
 
-		return nil
+			return nil
+		})
 	}
 
 	if err := walk(".", dir); err != nil {

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -140,10 +140,6 @@ func toDirEntryOrNil(dirEntry os.DirEntry, prefix string) (fs.Entry, error) {
 	return entryFromDirEntry(fi, prefix), nil
 }
 
-func (fsd *filesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return fs.IterateEntriesToReaddir(ctx, fsd)
-}
-
 func (fsd *filesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
 	fullPath := fsd.fullPath()
 

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -17,20 +17,6 @@ import (
 	"github.com/kopia/kopia/internal/testutil"
 )
 
-func iterateEntriesToReaddir(ctx context.Context, dir fs.Directory) (fs.Entries, error) {
-	entries := fs.Entries(nil)
-
-	err := dir.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
-		entries = append(entries, e)
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return entries, nil
-}
-
 type fileEnt struct {
 	size   int64
 	isFile bool
@@ -58,7 +44,7 @@ func TestFiles(t *testing.T) {
 		t.Errorf("error when dir empty directory: %v", err)
 	}
 
-	entries, err := iterateEntriesToReaddir(ctx, dir)
+	entries, err := fs.GetAllEntries(ctx, dir)
 	if err != nil {
 		t.Errorf("error gettind dir Entries: %v", err)
 	}
@@ -103,7 +89,7 @@ func TestFiles(t *testing.T) {
 		t.Errorf("error when dir directory with files: %v", err)
 	}
 
-	entries, err = iterateEntriesToReaddir(ctx, dir)
+	entries, err = fs.GetAllEntries(ctx, dir)
 	if err != nil {
 		t.Errorf("error gettind dir Entries: %v", err)
 	}

--- a/fs/localfs/local_fs_test.go
+++ b/fs/localfs/local_fs_test.go
@@ -17,6 +17,25 @@ import (
 	"github.com/kopia/kopia/internal/testutil"
 )
 
+func iterateEntriesToReaddir(ctx context.Context, dir fs.Directory) (fs.Entries, error) {
+	entries := fs.Entries(nil)
+
+	err := dir.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
+		entries = append(entries, e)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+type fileEnt struct {
+	size   int64
+	isFile bool
+}
+
 //nolint:gocyclo
 func TestFiles(t *testing.T) {
 	ctx := testlogging.Context(t)
@@ -39,7 +58,7 @@ func TestFiles(t *testing.T) {
 		t.Errorf("error when dir empty directory: %v", err)
 	}
 
-	entries, err := dir.Readdir(ctx)
+	entries, err := iterateEntriesToReaddir(ctx, dir)
 	if err != nil {
 		t.Errorf("error gettind dir Entries: %v", err)
 	}
@@ -56,35 +75,61 @@ func TestFiles(t *testing.T) {
 	assertNoError(t, os.Mkdir(filepath.Join(tmp, "z"), 0o777))
 	assertNoError(t, os.Mkdir(filepath.Join(tmp, "y"), 0o777))
 
+	expected := map[string]fileEnt{
+		"f1": {
+			size:   5,
+			isFile: true,
+		},
+		"f2": {
+			size:   4,
+			isFile: true,
+		},
+		"f3": {
+			size:   3,
+			isFile: true,
+		},
+		"y": {
+			size:   0,
+			isFile: false,
+		},
+		"z": {
+			size:   0,
+			isFile: false,
+		},
+	}
+
 	dir, err = Directory(tmp)
 	if err != nil {
 		t.Errorf("error when dir directory with files: %v", err)
 	}
 
-	entries, err = dir.Readdir(ctx)
+	entries, err = iterateEntriesToReaddir(ctx, dir)
 	if err != nil {
 		t.Errorf("error gettind dir Entries: %v", err)
 	}
 
 	goodCount := 0
 
-	if entries[0].Name() == "f1" && entries[0].Size() == 5 && entries[0].Mode().IsRegular() {
-		goodCount++
-	}
+	for _, found := range entries {
+		wanted, ok := expected[found.Name()]
+		if !ok {
+			continue
+		}
 
-	if entries[1].Name() == "f2" && entries[1].Size() == 4 && entries[1].Mode().IsRegular() {
-		goodCount++
-	}
+		if found.Size() != wanted.size {
+			continue
+		}
 
-	if entries[2].Name() == "f3" && entries[2].Size() == 3 && entries[2].Mode().IsRegular() {
-		goodCount++
-	}
+		if wanted.isFile {
+			if !found.Mode().IsRegular() {
+				continue
+			}
+		} else {
+			if !found.Mode().IsDir() {
+				continue
+			}
+		}
 
-	if entries[3].Name() == "y" && entries[3].Size() == 0 && entries[3].Mode().IsDir() {
-		goodCount++
-	}
-
-	if entries[4].Name() == "z" && entries[4].Size() == 0 && entries[4].Mode().IsDir() {
 		goodCount++
 	}
 
@@ -193,12 +238,12 @@ func verifyChild(t *testing.T, dir fs.Directory) {
 		t.Errorf("unexpected child size: %v, want %v", got, want)
 	}
 
-	if _, err = fs.ReadDirAndFindChild(ctx, dir, "f4"); !errors.Is(err, fs.ErrEntryNotFound) {
+	if _, err = fs.IterateEntriesAndFindChild(ctx, dir, "f4"); !errors.Is(err, fs.ErrEntryNotFound) {
 		t.Errorf("unexpected child error: %v", err)
 	}
 
-	// read child again, this time using ReadAndFindChild
-	child2, err := fs.ReadDirAndFindChild(ctx, dir, "f3")
+	// read child again, this time using IterateEntriesAndFindChild
+	child2, err := fs.IterateEntriesAndFindChild(ctx, dir, "f3")
 	if err != nil {
 		t.Errorf("child2 error: %v", err)
 	}

--- a/fs/localfs/localfs_benchmark_test.go
+++ b/fs/localfs/localfs_benchmark_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/kopia/kopia/fs"
 	"github.com/kopia/kopia/fs/localfs"
 )
 
@@ -56,6 +57,8 @@ func benchmarkReadDirWithCount(b *testing.B, fileCount int) {
 
 	for i := 0; i < b.N; i++ {
 		dir, _ := localfs.Directory(td)
-		dir.Readdir(ctx)
+		dir.IterateEntries(ctx, func(context.Context, fs.Entry) error {
+			return nil
+		})
 	}
 }

--- a/fs/localfs/shallow_fs.go
+++ b/fs/localfs/shallow_fs.go
@@ -119,10 +119,6 @@ func (fsd *shallowFilesystemDirectory) Child(ctx context.Context, name string) (
 	return nil, errors.New("shallowFilesystemDirectory.Child not supported")
 }
 
-func (fsd *shallowFilesystemDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return nil, errors.New("shallowFilesystemDirectory.Readdir not supported")
-}
-
 func (fsd *shallowFilesystemDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
 	return errors.New("shallowFilesystemDirectory.IterateEntries not supported")
 }

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -35,7 +35,7 @@ func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, e
 
 func (ld *loggingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 	timer := timetrack.StartTimer()
-	entries, err := ld.Directory.Readdir(ctx)
+	entries, err := fs.IterateEntriesToReaddir(ctx, ld.Directory)
 	dt := timer.Elapsed()
 	ld.options.printf(ld.options.prefix+"Readdir(%v) took %v and returned %v items", ld.relativePath, dt, len(entries))
 
@@ -44,7 +44,6 @@ func (ld *loggingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 		loggingEntries[i] = wrapWithOptions(entry, ld.options, ld.relativePath+"/"+entry.Name())
 	}
 
-	// nolint:wrapcheck
 	return loggingEntries, err
 }
 

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -33,18 +33,27 @@ func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, e
 	return wrapWithOptions(entry, ld.options, ld.relativePath+"/"+entry.Name()), nil
 }
 
-func (ld *loggingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
+func (ld *loggingDirectory) IterateEntries(ctx context.Context, callback func(context.Context, fs.Entry) error) error {
 	timer := timetrack.StartTimer()
-	entries, err := fs.IterateEntriesToReaddir(ctx, ld.Directory)
+	entries := fs.Entries(nil)
+	err := ld.Directory.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
+		entries = append(entries, wrapWithOptions(e, ld.options, ld.relativePath+"/"+e.Name()))
+		return nil
+	})
 	dt := timer.Elapsed()
 	ld.options.printf(ld.options.prefix+"Readdir(%v) took %v and returned %v items", ld.relativePath, dt, len(entries))
 
-	loggingEntries := make(fs.Entries, len(entries))
-	for i, entry := range entries {
-		loggingEntries[i] = wrapWithOptions(entry, ld.options, ld.relativePath+"/"+entry.Name())
+	if err != nil {
+		return err // nolint:wrapcheck
 	}
 
-	return loggingEntries, err
+	for _, e := range entries {
+		if err2 := callback(ctx, e); err2 != nil {
+			return err2
+		}
+	}
+
+	return nil
 }
 
 type loggingFile struct {

--- a/fs/loggingfs/loggingfs.go
+++ b/fs/loggingfs/loggingfs.go
@@ -35,20 +35,16 @@ func (ld *loggingDirectory) Child(ctx context.Context, name string) (fs.Entry, e
 
 func (ld *loggingDirectory) IterateEntries(ctx context.Context, callback func(context.Context, fs.Entry) error) error {
 	timer := timetrack.StartTimer()
-	entries := fs.Entries(nil)
-	err := ld.Directory.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
-		entries = append(entries, wrapWithOptions(e, ld.options, ld.relativePath+"/"+e.Name()))
-		return nil
-	})
+	entries, err := fs.GetAllEntries(ctx, ld.Directory)
 	dt := timer.Elapsed()
 	ld.options.printf(ld.options.prefix+"Readdir(%v) took %v and returned %v items", ld.relativePath, dt, len(entries))
 
 	if err != nil {
-		return err // nolint:wrapcheck
+		return err
 	}
 
 	for _, e := range entries {
-		if err2 := callback(ctx, e); err2 != nil {
+		if err2 := callback(ctx, wrapWithOptions(e, ld.options, ld.relativePath+"/"+e.Name())); err2 != nil {
 			return err2
 		}
 	}

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -70,12 +70,7 @@ type staticDirectory struct {
 // Child gets the named child of a directory.
 func (sd *staticDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
-	return fs.ReadDirAndFindChild(ctx, sd, name)
-}
-
-// Readdir gets the contents of a directory.
-func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return fs.IterateEntriesToReaddir(ctx, sd)
+	return fs.IterateEntriesAndFindChild(ctx, sd, name)
 }
 
 func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -64,7 +64,7 @@ func (e *virtualEntry) LocalFilesystemPath() string {
 // staticDirectory is an in-memory implementation of fs.Directory.
 type staticDirectory struct {
 	virtualEntry
-	entries fs.Entries
+	entries []fs.Entry
 }
 
 // Child gets the named child of a directory.
@@ -74,7 +74,7 @@ func (sd *staticDirectory) Child(ctx context.Context, name string) (fs.Entry, er
 }
 
 func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	for _, e := range append(fs.Entries(nil), sd.entries...) {
+	for _, e := range append([]fs.Entry{}, sd.entries...) {
 		if err := cb(ctx, e); err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.C
 }
 
 // NewStaticDirectory returns a virtual static directory.
-func NewStaticDirectory(name string, entries fs.Entries) fs.Directory {
+func NewStaticDirectory(name string, entries []fs.Entry) fs.Directory {
 	return &staticDirectory{
 		virtualEntry: virtualEntry{
 			name: name,

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -75,11 +75,17 @@ func (sd *staticDirectory) Child(ctx context.Context, name string) (fs.Entry, er
 
 // Readdir gets the contents of a directory.
 func (sd *staticDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return append(fs.Entries(nil), sd.entries...), nil
+	return fs.IterateEntriesToReaddir(ctx, sd)
 }
 
 func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.Context, fs.Entry) error) error {
-	return fs.ReaddirToIterate(ctx, sd, cb)
+	for _, e := range append(fs.Entries(nil), sd.entries...) {
+		if err := cb(ctx, e); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // NewStaticDirectory returns a virtual static directory.

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -39,12 +39,7 @@ func TestStreamingFile(t *testing.T) {
 		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), filename)
 	}
 
-	entries := fs.Entries(nil)
-
-	err = rootDir.IterateEntries(context.TODO(), func(innerCtx context.Context, e fs.Entry) error {
-		entries = append(entries, e)
-		return nil
-	})
+	entries, err := fs.GetAllEntries(context.TODO(), rootDir)
 	if err != nil {
 		t.Fatalf("error getting dir entries %v", err)
 	}

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -39,7 +39,7 @@ func TestStreamingFile(t *testing.T) {
 		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), filename)
 	}
 
-	entries, err := rootDir.Readdir(context.TODO())
+	entries, err := fs.IterateEntriesToReaddir(context.TODO(), rootDir)
 	if err != nil {
 		t.Fatalf("error getting dir entries %v", err)
 	}

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -39,7 +39,12 @@ func TestStreamingFile(t *testing.T) {
 		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), filename)
 	}
 
-	entries, err := fs.IterateEntriesToReaddir(context.TODO(), rootDir)
+	entries := fs.Entries(nil)
+
+	err = rootDir.IterateEntries(context.TODO(), func(innerCtx context.Context, e fs.Entry) error {
+		entries = append(entries, e)
+		return nil
+	})
 	if err != nil {
 		t.Fatalf("error getting dir entries %v", err)
 	}

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -28,7 +28,7 @@ func TestStreamingFile(t *testing.T) {
 	filename := "stream-file"
 	f := StreamingFileFromReader(filename, r)
 
-	rootDir := NewStaticDirectory("root", fs.Entries{f})
+	rootDir := NewStaticDirectory("root", []fs.Entry{f})
 
 	e, err := rootDir.Child(context.TODO(), filename)
 	if err != nil {

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -52,7 +52,7 @@ func maybeOID(e fs.Entry) string {
 func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directory, parent string) error {
 	log(ctx).Debugf("comparing directories %v (%v and %v)", parent, maybeOID(dir1), maybeOID(dir2))
 
-	var entries1, entries2 fs.Entries
+	var entries1, entries2 []fs.Entry
 
 	var err error
 
@@ -206,7 +206,7 @@ func compareEntry(e1, e2 fs.Entry, fullpath string, out io.Writer) bool {
 	return equal
 }
 
-func (c *Comparer) compareDirectoryEntries(ctx context.Context, entries1, entries2 fs.Entries, dirPath string) error {
+func (c *Comparer) compareDirectoryEntries(ctx context.Context, entries1, entries2 []fs.Entry, dirPath string) error {
 	e1byname := map[string]fs.Entry{}
 	for _, e1 := range entries1 {
 		e1byname[e1.Name()] = e1

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -57,14 +57,14 @@ func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directo
 	var err error
 
 	if dir1 != nil {
-		entries1, err = dir1.Readdir(ctx)
+		entries1, err = fs.IterateEntriesToReaddir(ctx, dir1)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read first directory %v", parent)
 		}
 	}
 
 	if dir2 != nil {
-		entries2, err = dir2.Readdir(ctx)
+		entries2, err = fs.IterateEntriesToReaddir(ctx, dir2)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read second directory %v", parent)
 		}

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -57,14 +57,14 @@ func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directo
 	var err error
 
 	if dir1 != nil {
-		entries1, err = iterateEntriesToReaddir(ctx, dir1)
+		entries1, err = fs.GetAllEntries(ctx, dir1)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read first directory %v", parent)
 		}
 	}
 
 	if dir2 != nil {
-		entries2, err = iterateEntriesToReaddir(ctx, dir2)
+		entries2, err = fs.GetAllEntries(ctx, dir2)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read second directory %v", parent)
 		}
@@ -309,20 +309,4 @@ func NewComparer(out io.Writer) (*Comparer, error) {
 	}
 
 	return &Comparer{out: out, tmpDir: tmp}, nil
-}
-
-func iterateEntriesToReaddir(ctx context.Context, dir fs.Directory) (fs.Entries, error) {
-	entries := fs.Entries(nil)
-
-	err := dir.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
-		entries = append(entries, e)
-		return nil
-	})
-	if err != nil {
-		return nil, err // nolint:wrapcheck
-	}
-
-	entries.Sort()
-
-	return entries, nil
 }

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -57,14 +57,14 @@ func (c *Comparer) compareDirectories(ctx context.Context, dir1, dir2 fs.Directo
 	var err error
 
 	if dir1 != nil {
-		entries1, err = fs.IterateEntriesToReaddir(ctx, dir1)
+		entries1, err = iterateEntriesToReaddir(ctx, dir1)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read first directory %v", parent)
 		}
 	}
 
 	if dir2 != nil {
-		entries2, err = fs.IterateEntriesToReaddir(ctx, dir2)
+		entries2, err = iterateEntriesToReaddir(ctx, dir2)
 		if err != nil {
 			return errors.Wrapf(err, "unable to read second directory %v", parent)
 		}
@@ -309,4 +309,20 @@ func NewComparer(out io.Writer) (*Comparer, error) {
 	}
 
 	return &Comparer{out: out, tmpDir: tmp}, nil
+}
+
+func iterateEntriesToReaddir(ctx context.Context, dir fs.Directory) (fs.Entries, error) {
+	entries := fs.Entries(nil)
+
+	err := dir.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
+		entries = append(entries, e)
+		return nil
+	})
+	if err != nil {
+		return nil, err // nolint:wrapcheck
+	}
+
+	entries.Sort()
+
+	return entries, nil
 }

--- a/internal/fshasher/fshasher.go
+++ b/internal/fshasher/fshasher.go
@@ -110,18 +110,15 @@ func header(ctx context.Context, fullpath string, e os.FileInfo) (*tar.Header, e
 }
 
 func writeDirectory(ctx context.Context, tw *tar.Writer, fullpath string, d fs.Directory) error {
-	entries, err := d.Readdir(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, e := range entries {
-		if err := write(ctx, tw, path.Join(fullpath, e.Name()), e); err != nil {
-			return err
+	err := d.IterateEntries(ctx, func(c context.Context, e fs.Entry) error {
+		if err2 := write(c, tw, path.Join(fullpath, e.Name()), e); err2 != nil {
+			return err2
 		}
-	}
 
-	return nil
+		return nil
+	})
+
+	return err
 }
 
 func writeFile(ctx context.Context, w io.Writer, f fs.File) error {

--- a/internal/fusemount/fusefs.go
+++ b/internal/fusemount/fusefs.go
@@ -114,7 +114,7 @@ func (dir *fuseDirectoryNode) directory() fs.Directory {
 }
 
 func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *fuse.EntryOut) (*gofusefs.Inode, syscall.Errno) {
-	entries, err := dir.directory().Readdir(ctx)
+	e, err := fs.IterateEntriesAndFindChild(ctx, dir.directory(), fileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, syscall.ENOENT
@@ -125,7 +125,6 @@ func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *
 		return nil, syscall.EIO
 	}
 
-	e := entries.FindByName(fileName)
 	if e == nil {
 		return nil, syscall.ENOENT
 	}
@@ -147,18 +146,18 @@ func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *
 }
 
 func (dir *fuseDirectoryNode) Readdir(ctx context.Context) (gofusefs.DirStream, syscall.Errno) {
-	entries, err := dir.directory().Readdir(ctx)
-	if err != nil {
-		log(ctx).Errorf("error reading directory %v: %v", dir.entry.Name(), err)
-		return nil, syscall.EIO
-	}
-
 	result := []fuse.DirEntry{}
-	for _, e := range entries {
+
+	err := dir.directory().IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
 		result = append(result, fuse.DirEntry{
 			Name: e.Name(),
 			Mode: entryToFuseMode(e),
 		})
+		return nil
+	})
+	if err != nil {
+		log(ctx).Errorf("error reading directory %v: %v", dir.entry.Name(), err)
+		return nil, syscall.EIO
 	}
 
 	return gofusefs.NewListDirStream(result), gofusefs.OK

--- a/internal/fusemount/fusefs.go
+++ b/internal/fusemount/fusefs.go
@@ -114,7 +114,7 @@ func (dir *fuseDirectoryNode) directory() fs.Directory {
 }
 
 func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *fuse.EntryOut) (*gofusefs.Inode, syscall.Errno) {
-	e, err := fs.IterateEntriesAndFindChild(ctx, dir.directory(), fileName)
+	e, err := dir.directory().Child(ctx, fileName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, syscall.ENOENT
@@ -146,6 +146,7 @@ func (dir *fuseDirectoryNode) Lookup(ctx context.Context, fileName string, out *
 }
 
 func (dir *fuseDirectoryNode) Readdir(ctx context.Context) (gofusefs.DirStream, syscall.Errno) {
+	// TODO: Slice not required as DirStream is also an iterator.
 	result := []fuse.DirEntry{}
 
 	err := dir.directory().IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -81,7 +81,7 @@ func (e *entry) LocalFilesystemPath() string {
 type Directory struct {
 	entry
 
-	children     fs.Entries
+	children     []fs.Entry
 	readdirError error
 	onReaddir    func()
 }
@@ -209,7 +209,7 @@ func (imd *Directory) addChild(e fs.Entry) {
 	}
 
 	imd.children = append(imd.children, e)
-	imd.children.Sort()
+	fs.Sort(imd.children)
 }
 
 func (imd *Directory) resolveSubdir(name string) (parent *Directory, leaf string) {
@@ -226,7 +226,7 @@ func (imd *Directory) Subdir(name ...string) *Directory {
 	i := imd
 
 	for _, n := range name {
-		i2 := i.children.FindByName(n)
+		i2 := fs.FindByName(i.children, n)
 		if i2 == nil {
 			panic(fmt.Sprintf("'%s' not found in '%s'", n, i.Name()))
 		}
@@ -267,7 +267,7 @@ func (imd *Directory) OnReaddir(cb func()) {
 
 // Child gets the named child of a directory.
 func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) {
-	e := imd.children.FindByName(name)
+	e := fs.FindByName(imd.children, name)
 	if e != nil {
 		return e, nil
 	}
@@ -285,7 +285,7 @@ func (imd *Directory) IterateEntries(ctx context.Context, cb func(context.Contex
 		imd.onReaddir()
 	}
 
-	for _, e := range append(fs.Entries(nil), imd.children...) {
+	for _, e := range append([]fs.Entry{}, imd.children...) {
 		if err := cb(ctx, e); err != nil {
 			return err
 		}

--- a/internal/webdavmount/webdavmount.go
+++ b/internal/webdavmount/webdavmount.go
@@ -109,6 +109,7 @@ type webdavDir struct {
 // nolint:gochecknoglobals
 var symlinksAreUnsupportedLogged = new(int32)
 
+// TODO: (bug) This incorrectly truncates the entries in the directory and does not allow pagination.
 func (d *webdavDir) Readdir(n int) ([]os.FileInfo, error) {
 	var fis []os.FileInfo
 
@@ -218,7 +219,7 @@ func (w *webdavFS) findEntry(ctx context.Context, path string) (fs.Entry, error)
 
 		var err error
 
-		e, err = fs.IterateEntriesAndFindChild(ctx, d, p)
+		e, err = d.Child(ctx, p)
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading directory")
 		}

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -257,12 +257,7 @@ func (c *copier) copyDirectory(ctx context.Context, d fs.Directory, targetPath s
 }
 
 func (c *copier) copyDirectoryContent(ctx context.Context, d fs.Directory, targetPath string, currentdepth, maxdepth int32, onCompletion parallelwork.CallbackFunc) error {
-	entries := fs.Entries(nil)
-
-	err := d.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
-		entries = append(entries, e)
-		return nil
-	})
+	entries, err := fs.GetAllEntries(ctx, d)
 	if err != nil {
 		return errors.Wrap(err, "error reading directory")
 	}

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -257,7 +257,12 @@ func (c *copier) copyDirectory(ctx context.Context, d fs.Directory, targetPath s
 }
 
 func (c *copier) copyDirectoryContent(ctx context.Context, d fs.Directory, targetPath string, currentdepth, maxdepth int32, onCompletion parallelwork.CallbackFunc) error {
-	entries, err := fs.IterateEntriesToReaddir(ctx, d)
+	entries := fs.Entries(nil)
+
+	err := d.IterateEntries(ctx, func(innerCtx context.Context, e fs.Entry) error {
+		entries = append(entries, e)
+		return nil
+	})
 	if err != nil {
 		return errors.Wrap(err, "error reading directory")
 	}

--- a/snapshot/restore/restore.go
+++ b/snapshot/restore/restore.go
@@ -257,7 +257,7 @@ func (c *copier) copyDirectory(ctx context.Context, d fs.Directory, targetPath s
 }
 
 func (c *copier) copyDirectoryContent(ctx context.Context, d fs.Directory, targetPath string, currentdepth, maxdepth int32, onCompletion parallelwork.CallbackFunc) error {
-	entries, err := d.Readdir(ctx)
+	entries, err := fs.IterateEntriesToReaddir(ctx, d)
 	if err != nil {
 		return errors.Wrap(err, "error reading directory")
 	}

--- a/snapshot/snapshotfs/objref.go
+++ b/snapshot/snapshotfs/objref.go
@@ -45,12 +45,11 @@ func GetNestedEntry(ctx context.Context, startingDir fs.Entry, pathElements []st
 			return nil, errors.Errorf("entry not found %q: parent is not a directory", part)
 		}
 
-		entries, err := dir.Readdir(ctx)
+		e, err := fs.IterateEntriesAndFindChild(ctx, dir, part)
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading directory")
 		}
 
-		e := entries.FindByName(part)
 		if e == nil {
 			return nil, errors.Errorf("entry not found: %q", part)
 		}

--- a/snapshot/snapshotfs/objref.go
+++ b/snapshot/snapshotfs/objref.go
@@ -45,7 +45,7 @@ func GetNestedEntry(ctx context.Context, startingDir fs.Entry, pathElements []st
 			return nil, errors.Errorf("entry not found %q: parent is not a directory", part)
 		}
 
-		e, err := fs.IterateEntriesAndFindChild(ctx, dir, part)
+		e, err := dir.Child(ctx, part)
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading directory")
 		}

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -288,7 +288,7 @@ func SnapshotRoot(rep repo.Repository, man *snapshot.Manifest) (fs.Entry, error)
 func AutoDetectEntryFromObjectID(ctx context.Context, rep repo.Repository, oid object.ID, maybeName string) fs.Entry {
 	if IsDirectoryID(oid) {
 		dirEntry := DirectoryEntry(rep, oid, nil)
-		if _, err := dirEntry.Readdir(ctx); err == nil {
+		if _, err := fs.IterateEntriesToReaddir(ctx, dirEntry); err == nil {
 			repoFSLog(ctx).Debugf("%v auto-detected as directory", oid)
 			return dirEntry
 		}

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -140,10 +140,6 @@ func (rd *repositoryDirectory) IterateEntries(ctx context.Context, cb func(conte
 	return nil
 }
 
-func (rd *repositoryDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return fs.IterateEntriesToReaddir(ctx, rd)
-}
-
 func (rd *repositoryDirectory) ensureDirEntriesLoaded(ctx context.Context) error {
 	rd.mu.Lock()
 	defer rd.mu.Unlock()
@@ -288,7 +284,9 @@ func SnapshotRoot(rep repo.Repository, man *snapshot.Manifest) (fs.Entry, error)
 func AutoDetectEntryFromObjectID(ctx context.Context, rep repo.Repository, oid object.ID, maybeName string) fs.Entry {
 	if IsDirectoryID(oid) {
 		dirEntry := DirectoryEntry(rep, oid, nil)
-		if _, err := fs.IterateEntriesToReaddir(ctx, dirEntry); err == nil {
+		if err := dirEntry.IterateEntries(ctx, func(context.Context, fs.Entry) error {
+			return nil
+		}); err == nil {
 			repoFSLog(ctx).Debugf("%v auto-detected as directory", oid)
 			return dirEntry
 		}

--- a/snapshot/snapshotfs/snapshot_tree_walker.go
+++ b/snapshot/snapshotfs/snapshot_tree_walker.go
@@ -48,7 +48,9 @@ func (w *TreeWalker) ReportError(ctx context.Context, entryPath string, err erro
 
 	repoFSLog(ctx).Errorf("error processing %v: %v", entryPath, err)
 
-	if len(w.errors) < w.options.MaxErrors {
+	// Record one error if we can't get too many errors so that at least that one
+	// can be returned if it's the only one.
+	if len(w.errors) < w.options.MaxErrors || (w.options.MaxErrors <= 0 && len(w.errors) == 0) {
 		w.errors = append(w.errors, err)
 	}
 

--- a/snapshot/snapshotfs/source_directories_test.go
+++ b/snapshot/snapshotfs/source_directories_test.go
@@ -81,19 +81,19 @@ func TestAllSources(t *testing.T) {
 func iterateAllNames(ctx context.Context, t *testing.T, dir fs.Directory, prefix string) []string {
 	t.Helper()
 
-	entries, err := dir.Readdir(ctx)
-	require.NoError(t, err)
-
 	result := []string{}
 
-	for _, ent := range entries {
+	err := dir.IterateEntries(ctx, func(innerCtx context.Context, ent fs.Entry) error {
 		if ent.IsDir() {
 			result = append(result, prefix+ent.Name()+"/")
 			result = append(result, iterateAllNames(ctx, t, ent.(fs.Directory), prefix+ent.Name()+"/")...)
 		} else {
 			result = append(result, prefix+ent.Name())
 		}
-	}
+
+		return nil
+	})
+	require.NoError(t, err)
 
 	return result
 }

--- a/snapshot/snapshotfs/source_directories_test.go
+++ b/snapshot/snapshotfs/source_directories_test.go
@@ -50,45 +50,49 @@ func TestAllSources(t *testing.T) {
 
 	as := AllSourcesEntry(env.RepositoryWriter)
 	gotNames := iterateAllNames(ctx, t, as, "")
-	wantNames := []string{
-		"another-user@some-host/",
-		"another-user@some-host/__root/",
-		"another-user@some-host/__root/20200101-120103/",
-		"another-user@some-host/tmp/",
-		"another-user@some-host/tmp/20200101-120103/",
-		"another-user@some-host/var/",
-		"another-user@some-host/var/20200101-120103/",
-		"some-user@some-host/",
-		"some-user@some-host/c_some_Path/",
-		"some-user@some-host/c_some_Path/20200101-120103/",
-		"some-user@some-host/c_some_path (2)/",
-		"some-user@some-host/c_some_path (2)/20200101-120103/",
-		"some-user@some-host/c_some_path (2)/20200101-120104/",
-		"some-user@some-host/c_some_path (2)/20200101-120105/",
-		"some_user@some-host/",
-		"some_user@some-host/c_some_path/",
-		"some_user@some-host/c_some_path/20200101-130103/",
-		"some_user@some-host/c_some_path/20200101-130104/",
-		"some_user@some-host (2)/",
-		"some_user@some-host (2)/c_some_path/",
-		"some_user@some-host (2)/c_some_path/20200101-140103/",
-		"some_user@some-host (2)/c_some_path/20200101-140104/",
+	wantNames := map[string]struct{}{
+		"another-user@some-host/":                              {},
+		"another-user@some-host/__root/":                       {},
+		"another-user@some-host/__root/20200101-120103/":       {},
+		"another-user@some-host/tmp/":                          {},
+		"another-user@some-host/tmp/20200101-120103/":          {},
+		"another-user@some-host/var/":                          {},
+		"another-user@some-host/var/20200101-120103/":          {},
+		"some-user@some-host/":                                 {},
+		"some-user@some-host/c_some_Path/":                     {},
+		"some-user@some-host/c_some_Path/20200101-120103/":     {},
+		"some-user@some-host/c_some_path (2)/":                 {},
+		"some-user@some-host/c_some_path (2)/20200101-120103/": {},
+		"some-user@some-host/c_some_path (2)/20200101-120104/": {},
+		"some-user@some-host/c_some_path (2)/20200101-120105/": {},
+		"some_user@some-host/":                                 {},
+		"some_user@some-host/c_some_path/":                     {},
+		"some_user@some-host/c_some_path/20200101-130103/":     {},
+		"some_user@some-host/c_some_path/20200101-130104/":     {},
+		"some_user@some-host (2)/":                             {},
+		"some_user@some-host (2)/c_some_path/":                 {},
+		"some_user@some-host (2)/c_some_path/20200101-140103/": {},
+		"some_user@some-host (2)/c_some_path/20200101-140104/": {},
 	}
 
 	require.Equal(t, wantNames, gotNames)
 }
 
-func iterateAllNames(ctx context.Context, t *testing.T, dir fs.Directory, prefix string) []string {
+func iterateAllNames(ctx context.Context, t *testing.T, dir fs.Directory, prefix string) map[string]struct{} {
 	t.Helper()
 
-	result := []string{}
+	result := map[string]struct{}{}
 
 	err := dir.IterateEntries(ctx, func(innerCtx context.Context, ent fs.Entry) error {
 		if ent.IsDir() {
-			result = append(result, prefix+ent.Name()+"/")
-			result = append(result, iterateAllNames(ctx, t, ent.(fs.Directory), prefix+ent.Name()+"/")...)
+			result[prefix+ent.Name()+"/"] = struct{}{}
+			childEntries := iterateAllNames(ctx, t, ent.(fs.Directory), prefix+ent.Name()+"/")
+
+			for k, v := range childEntries {
+				result[k] = v
+			}
 		} else {
-			result = append(result, prefix+ent.Name())
+			result[prefix+ent.Name()] = struct{}{}
 		}
 
 		return nil

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -663,7 +663,7 @@ func TestUpload_VirtualDirectoryWithStreamingFile(t *testing.T) {
 
 	w.Close()
 
-	staticRoot := virtualfs.NewStaticDirectory("rootdir", fs.Entries{
+	staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
 		virtualfs.StreamingFileFromReader("stream-file", r),
 	})
 

--- a/tests/tools/kopiaclient/kopiaclient.go
+++ b/tests/tools/kopiaclient/kopiaclient.go
@@ -209,7 +209,7 @@ func (kc *KopiaClient) getStorage(ctx context.Context, repoDir, bucketName strin
 // getSourceForKeyVal creates a virtual directory for `key` that contains a single virtual file that
 // reads its contents from `val`.
 func (kc *KopiaClient) getSourceForKeyVal(key string, val []byte) fs.Entry {
-	return virtualfs.NewStaticDirectory(key, fs.Entries{
+	return virtualfs.NewStaticDirectory(key, []fs.Entry{
 		virtualfs.StreamingFileFromReader(dataFileName, bytes.NewReader(val)),
 	})
 }


### PR DESCRIPTION
Not strictly necessary to getting `StreamingDirectory`s working, but does cleanup the codebase. Also PR-ed upstream pending merge. PR-ed here to get some extra eyes if people are interested