### PR TITLE
Allow dynamically creating entries in directories

### DIFF
--- a/fs/entry.go
+++ b/fs/entry.go
@@ -58,6 +58,8 @@ type Directory interface {
 	Entry
 	Child(ctx context.Context, name string) (Entry, error)
 	IterateEntries(ctx context.Context, cb func(context.Context, Entry) error) error
+	// MultipleIterations returns true if the Directory supports iterating through
+	// the entries multiple times. Otherwise it returns false.
 	MultipleIterations() bool
 }
 

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -58,10 +58,6 @@ type Directory interface {
 	Entry
 	Child(ctx context.Context, name string) (Entry, error)
 	IterateEntries(ctx context.Context, cb func(context.Context, Entry) error) error
-}
-
-// DirectoryWithIterationRestrictions allows callers to check if IterateEntries is safe to call multiple times.
-type DirectoryWithIterationRestrictions interface {
 	MultipleIterations() bool
 }
 

--- a/fs/entry.go
+++ b/fs/entry.go
@@ -60,6 +60,11 @@ type Directory interface {
 	IterateEntries(ctx context.Context, cb func(context.Context, Entry) error) error
 }
 
+// DirectoryWithIterationRestrictions allows callers to check if IterateEntries is safe to call multiple times.
+type DirectoryWithIterationRestrictions interface {
+	MultipleIterations() bool
+}
+
 // DirectoryWithSummary is optionally implemented by Directory that provide summary.
 type DirectoryWithSummary interface {
 	Summary(ctx context.Context) (*DirectorySummary, error)

--- a/fs/localfs/local_fs.go
+++ b/fs/localfs/local_fs.go
@@ -102,6 +102,10 @@ type filesystemErrorEntry struct {
 	err error
 }
 
+func (fsd *filesystemDirectory) MultipleIterations() bool {
+	return true
+}
+
 func (fsd *filesystemDirectory) Size() int64 {
 	// force directory size to always be zero
 	return 0

--- a/fs/localfs/shallow_fs.go
+++ b/fs/localfs/shallow_fs.go
@@ -115,6 +115,10 @@ func (fsf *shallowFilesystemFile) Open(ctx context.Context) (fs.Reader, error) {
 	return nil, errors.New("shallowFilesystemFile.Open not supported")
 }
 
+func (fsd *shallowFilesystemDirectory) MultipleIterations() bool {
+	return false
+}
+
 func (fsd *shallowFilesystemDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	return nil, errors.New("shallowFilesystemDirectory.Child not supported")
 }

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -114,10 +114,6 @@ func (sd *streamingDirectory) Child(ctx context.Context, name string) (fs.Entry,
 	return nil, errChildNotSupported
 }
 
-func (sd *streamingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
-	return fs.IterateEntriesToReaddir(ctx, sd)
-}
-
 var errIteratorAlreadyUsed = errors.New("cannot use streaming directory iterator more than once if not MultipleIterations") // +checklocksignore: mu
 
 func (sd *streamingDirectory) getIterator() (func(context.Context, func(context.Context, fs.Entry) error) error, error) {

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -103,9 +103,8 @@ type streamingDirectory struct {
 	virtualEntry
 	// Used to generate the next entry and execute the callback on it.
 	// +checklocks:mu
-	callback           func(context.Context, func(context.Context, fs.Entry) error) error
-	multipleIterations bool
-	mu                 sync.Mutex
+	callback func(context.Context, func(context.Context, fs.Entry) error) error
+	mu       sync.Mutex
 }
 
 var errChildNotSupported = errors.New("streamingDirectory.Child not supported")
@@ -125,10 +124,7 @@ func (sd *streamingDirectory) getIterator() (func(context.Context, func(context.
 	}
 
 	cb := sd.callback
-
-	if !sd.MultipleIterations() {
-		sd.callback = nil
-	}
+	sd.callback = nil
 
 	return cb, nil
 }
@@ -146,7 +142,7 @@ func (sd *streamingDirectory) IterateEntries(
 }
 
 func (sd *streamingDirectory) MultipleIterations() bool {
-	return sd.multipleIterations
+	return false
 }
 
 // NewStreamingDirectory returns a directory that will call the given function
@@ -154,15 +150,13 @@ func (sd *streamingDirectory) MultipleIterations() bool {
 func NewStreamingDirectory(
 	name string,
 	callback func(context.Context, func(context.Context, fs.Entry) error) error,
-	multipleIterations bool,
 ) fs.Directory {
 	return &streamingDirectory{
 		virtualEntry: virtualEntry{
 			name: name,
 			mode: defaultPermissions | os.ModeDir,
 		},
-		callback:           callback,
-		multipleIterations: multipleIterations,
+		callback: callback,
 	}
 }
 

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -113,7 +113,7 @@ func (sd *streamingDirectory) Child(ctx context.Context, name string) (fs.Entry,
 	return nil, errChildNotSupported
 }
 
-var errIteratorAlreadyUsed = errors.New("cannot use streaming directory iterator more than once if not MultipleIterations") // +checklocksignore: mu
+var errIteratorAlreadyUsed = errors.New("cannot use streaming directory iterator more than once") // +checklocksignore: mu
 
 func (sd *streamingDirectory) getIterator() (func(context.Context, func(context.Context, fs.Entry) error) error, error) {
 	sd.mu.Lock()

--- a/fs/virtualfs/virtualfs.go
+++ b/fs/virtualfs/virtualfs.go
@@ -84,6 +84,10 @@ func (sd *staticDirectory) IterateEntries(ctx context.Context, cb func(context.C
 	return nil
 }
 
+func (sd *staticDirectory) MultipleIterations() bool {
+	return true
+}
+
 // NewStaticDirectory returns a virtual static directory.
 func NewStaticDirectory(name string, entries []fs.Entry) fs.Directory {
 	return &staticDirectory{
@@ -114,7 +118,7 @@ func (sd *streamingDirectory) Readdir(ctx context.Context) (fs.Entries, error) {
 	return fs.IterateEntriesToReaddir(ctx, sd)
 }
 
-var errIteratorAlreadyUsed = errors.New("cannot use streaming directory iterator more than once if not MultipleIterations")
+var errIteratorAlreadyUsed = errors.New("cannot use streaming directory iterator more than once if not MultipleIterations") // +checklocksignore: mu
 
 func (sd *streamingDirectory) getIterator() (func(context.Context, func(context.Context, fs.Entry) error) error, error) {
 	sd.mu.Lock()
@@ -201,9 +205,8 @@ func StreamingFileFromReader(name string, reader io.Reader) fs.StreamingFile {
 }
 
 var (
-	_ fs.Directory                          = &staticDirectory{}
-	_ fs.Directory                          = &streamingDirectory{}
-	_ fs.DirectoryWithIterationRestrictions = &streamingDirectory{}
-	_ fs.StreamingFile                      = &virtualFile{}
-	_ fs.Entry                              = &virtualEntry{}
+	_ fs.Directory     = &staticDirectory{}
+	_ fs.Directory     = &streamingDirectory{}
+	_ fs.StreamingFile = &virtualFile{}
+	_ fs.Entry         = &virtualEntry{}
 )

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -131,7 +131,7 @@ func TestStreamingDirectory(t *testing.T) {
 		true,
 	)
 
-	entries, err := rootDir.Readdir(context.TODO())
+	entries, err := fs.GetAllEntries(context.TODO(), rootDir)
 	if err != nil {
 		t.Fatalf("error getting dir entries %v", err)
 	}
@@ -187,13 +187,7 @@ func TestStreamingDirectory_MultipleIterations(t *testing.T) {
 				iterations,
 			)
 
-			entries := fs.Entries(nil)
-			iterFunc := func(innerCtx context.Context, e fs.Entry) error {
-				entries = append(entries, e)
-				return nil
-			}
-
-			err := rootDir.IterateEntries(context.TODO(), iterFunc)
+			entries, err := fs.GetAllEntries(context.TODO(), rootDir)
 			if err != nil {
 				t.Fatalf("error getting directory entries once")
 			}
@@ -202,9 +196,7 @@ func TestStreamingDirectory_MultipleIterations(t *testing.T) {
 				t.Fatalf("unexpected number of entries: (got) %v, (expected) %v", len(entries), 1)
 			}
 
-			entries = nil
-
-			err = rootDir.IterateEntries(context.TODO(), iterFunc)
+			_, err = fs.GetAllEntries(context.TODO(), rootDir)
 			if iterations && err != nil {
 				t.Fatalf("unexpected error on second directory iteration: %v", err)
 			} else if !iterations && err == nil {

--- a/fs/virtualfs/virtualfs_test.go
+++ b/fs/virtualfs/virtualfs_test.go
@@ -1,6 +1,7 @@
 package virtualfs
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"os"
@@ -8,6 +9,10 @@ import (
 	"testing"
 
 	"github.com/kopia/kopia/fs"
+)
+
+const (
+	testFileName = "stream-file"
 )
 
 func TestStreamingFile(t *testing.T) {
@@ -25,18 +30,17 @@ func TestStreamingFile(t *testing.T) {
 
 	w.Close()
 
-	filename := "stream-file"
-	f := StreamingFileFromReader(filename, r)
+	f := StreamingFileFromReader(testFileName, r)
 
 	rootDir := NewStaticDirectory("root", []fs.Entry{f})
 
-	e, err := rootDir.Child(context.TODO(), filename)
+	e, err := rootDir.Child(context.TODO(), testFileName)
 	if err != nil {
 		t.Fatalf("error getting child entry: %v", err)
 	}
 
-	if e.Name() != filename {
-		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), filename)
+	if e.Name() != testFileName {
+		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), testFileName)
 	}
 
 	entries, err := fs.GetAllEntries(context.TODO(), rootDir)
@@ -80,8 +84,7 @@ func TestStreamingFileGetReader(t *testing.T) {
 
 	w.Close()
 
-	filename := "stream-file"
-	f := StreamingFileFromReader(filename, r)
+	f := StreamingFileFromReader(testFileName, r)
 
 	// Read and compare data
 	reader, err := f.GetReader(context.TODO())
@@ -107,5 +110,101 @@ func TestStreamingFileGetReader(t *testing.T) {
 
 	if !errors.Is(err, errReaderAlreadyUsed) {
 		t.Fatalf("did not get expected error: (actual) %v != %v (expected)", err, errReaderAlreadyUsed)
+	}
+}
+
+func TestStreamingDirectory(t *testing.T) {
+	// Create a temporary file with test data
+	content := []byte("Temporary file content")
+	r := bytes.NewReader(content)
+
+	f := StreamingFileFromReader(testFileName, r)
+
+	rootDir := NewStreamingDirectory(
+		"root",
+		func(
+			ctx context.Context,
+			callback func(context.Context, fs.Entry) error,
+		) error {
+			return callback(ctx, f)
+		},
+	)
+
+	entries, err := rootDir.Readdir(context.TODO())
+	if err != nil {
+		t.Fatalf("error getting dir entries %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("expected directory with 1 entry, got %v", entries)
+	}
+
+	e := entries[0]
+	if e.Name() != testFileName {
+		t.Fatalf("did not get expected filename: (actual) %v != %v (expected)", e.Name(), testFileName)
+	}
+
+	// Read and compare data
+	reader, err := f.GetReader(context.TODO())
+	if err != nil {
+		t.Fatalf("error getting streaming file reader: %v", err)
+	}
+
+	result := make([]byte, len(content))
+
+	if _, err = reader.Read(result); err != nil {
+		t.Fatalf("error reading streaming file: %v", err)
+	}
+
+	if !reflect.DeepEqual(result, content) {
+		t.Fatalf("did not get expected file content: (actual) %v != %v (expected)", result, content)
+	}
+}
+
+var errCallback = errors.New("callback error")
+
+func TestStreamingDirectory_ReturnsCallbackError(t *testing.T) {
+	// Create a temporary file with test data
+	content := []byte("Temporary file content")
+	r := bytes.NewReader(content)
+
+	f := StreamingFileFromReader(testFileName, r)
+
+	rootDir := NewStreamingDirectory(
+		"root",
+		func(
+			ctx context.Context,
+			callback func(context.Context, fs.Entry) error,
+		) error {
+			return callback(ctx, f)
+		},
+	)
+
+	err := rootDir.IterateEntries(context.TODO(), func(context.Context, fs.Entry) error {
+		return errCallback
+	})
+	if !errors.Is(err, errCallback) {
+		t.Fatalf("expected error getting dir entries: (got) %v, (expected) %v", err, errCallback)
+	}
+}
+
+var errIteration = errors.New("iteration error")
+
+func TestStreamingDirectory_ReturnsReadDirError(t *testing.T) {
+	rootDir := NewStreamingDirectory(
+		"root",
+		func(
+			ctx context.Context,
+			callback func(context.Context, fs.Entry) error,
+		) error {
+			return errIteration
+		},
+	)
+
+	err := rootDir.IterateEntries(context.TODO(), func(context.Context, fs.Entry) error {
+		return nil
+	})
+	if !errors.Is(err, errIteration) {
+		t.Fatalf("expected error getting dir entries: (got) %v, (expected) %v", err, errIteration)
 	}
 }

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -353,6 +353,21 @@ func NewDirectory() *Directory {
 	}
 }
 
+// NewFile returns a new mock file with the given name, contents, and mode.
+func NewFile(name string, content []byte, permissions os.FileMode) *File {
+	return &File{
+		entry: entry{
+			name:    name,
+			mode:    permissions,
+			size:    int64(len(content)),
+			modTime: DefaultModTime,
+		},
+		source: func() (ReaderSeekerCloser, error) {
+			return readerSeekerCloser{bytes.NewReader(content)}, nil
+		},
+	}
+}
+
 // ErrorEntry is mock in-memory implementation of fs.ErrorEntry.
 type ErrorEntry struct {
 	entry

--- a/internal/mockfs/mockfs.go
+++ b/internal/mockfs/mockfs.go
@@ -265,6 +265,11 @@ func (imd *Directory) OnReaddir(cb func()) {
 	imd.onReaddir = cb
 }
 
+// MultipleIterations returns whether this directory can be iterated through multiple times.
+func (imd *Directory) MultipleIterations() bool {
+	return true
+}
+
 // Child gets the named child of a directory.
 func (imd *Directory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	e := fs.FindByName(imd.children, name)

--- a/snapshot/snapshotfs/all_sources.go
+++ b/snapshot/snapshotfs/all_sources.go
@@ -53,6 +53,10 @@ func (s *repositoryAllSources) LocalFilesystemPath() string {
 	return ""
 }
 
+func (s *repositoryAllSources) MultipleIterations() bool {
+	return true
+}
+
 func (s *repositoryAllSources) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)

--- a/snapshot/snapshotfs/estimate.go
+++ b/snapshot/snapshotfs/estimate.go
@@ -125,7 +125,7 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTr
 	case fs.Directory:
 		atomic.AddInt32(&stats.TotalDirectoryCount, 1)
 
-		if r, ok := entry.(fs.DirectoryWithIterationRestrictions); ok && !r.MultipleIterations() {
+		if !entry.MultipleIterations() {
 			return nil
 		}
 

--- a/snapshot/snapshotfs/estimate.go
+++ b/snapshot/snapshotfs/estimate.go
@@ -125,6 +125,10 @@ func estimate(ctx context.Context, relativePath string, entry fs.Entry, policyTr
 	case fs.Directory:
 		atomic.AddInt32(&stats.TotalDirectoryCount, 1)
 
+		if r, ok := entry.(fs.DirectoryWithIterationRestrictions); ok && !r.MultipleIterations() {
+			return nil
+		}
+
 		progress.Processing(ctx, relativePath)
 
 		err := entry.IterateEntries(ctx, func(c context.Context, child fs.Entry) error {

--- a/snapshot/snapshotfs/estimate_test.go
+++ b/snapshot/snapshotfs/estimate_test.go
@@ -1,4 +1,4 @@
-package snapshotfs
+package snapshotfs_test
 
 import (
 	"context"
@@ -9,6 +9,7 @@ import (
 	"github.com/kopia/kopia/internal/mockfs"
 	"github.com/kopia/kopia/snapshot"
 	"github.com/kopia/kopia/snapshot/policy"
+	"github.com/kopia/kopia/snapshot/snapshotfs"
 )
 
 type fakeProgress struct {
@@ -22,10 +23,11 @@ func (p *fakeProgress) Processing(context.Context, string) {}
 
 func (p *fakeProgress) Error(context.Context, string, error, bool) {}
 
+// +checklocksignore.
 func (p *fakeProgress) Stats(
 	ctx context.Context,
 	s *snapshot.Stats,
-	includedFiles, excludedFiles SampleBuckets,
+	includedFiles, excludedFiles snapshotfs.SampleBuckets,
 	excludedDirs []string,
 	final bool,
 ) {
@@ -66,7 +68,7 @@ func TestEstimate_SkipsStreamingDirectory(t *testing.T) {
 		expectedErrors:      0,
 	}
 
-	err := Estimate(context.TODO(), nil, rootDir, policyTree, p, 1)
+	err := snapshotfs.Estimate(context.TODO(), nil, rootDir, policyTree, p, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/snapshot/snapshotfs/estimate_test.go
+++ b/snapshot/snapshotfs/estimate_test.go
@@ -1,0 +1,73 @@
+package snapshotfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kopia/kopia/fs"
+	"github.com/kopia/kopia/fs/virtualfs"
+	"github.com/kopia/kopia/internal/mockfs"
+	"github.com/kopia/kopia/snapshot"
+	"github.com/kopia/kopia/snapshot/policy"
+)
+
+type fakeProgress struct {
+	t                   *testing.T
+	expectedFiles       int32
+	expectedDirectories int32
+	expectedErrors      int32
+}
+
+func (p *fakeProgress) Processing(context.Context, string) {}
+
+func (p *fakeProgress) Error(context.Context, string, error, bool) {}
+
+func (p *fakeProgress) Stats(
+	ctx context.Context,
+	s *snapshot.Stats,
+	includedFiles, excludedFiles SampleBuckets,
+	excludedDirs []string,
+	final bool,
+) {
+	if !final {
+		return
+	}
+
+	if got := s.ErrorCount; got != p.expectedErrors {
+		p.t.Errorf("unexpected errors encountered: (actual) %v != %v (expected)", got, p.expectedErrors)
+	}
+
+	if got := s.TotalFileCount; got != p.expectedFiles {
+		p.t.Errorf("unexpected files counted: (actual) %v != %v (expected)", got, p.expectedFiles)
+	}
+
+	if got := s.TotalDirectoryCount; got != p.expectedDirectories {
+		p.t.Errorf("unexpected directory count: (actual) %v != %v (expected)", got, p.expectedDirectories)
+	}
+}
+
+func TestEstimate_SkipsStreamingDirectory(t *testing.T) {
+	f := mockfs.NewFile("f1", []byte{1, 2, 3}, 0o777)
+
+	rootDir := virtualfs.NewStaticDirectory("root", []fs.Entry{
+		virtualfs.NewStreamingDirectory(
+			"a-dir",
+			func(ctx context.Context, callback func(context.Context, fs.Entry) error) error {
+				return callback(ctx, f)
+			},
+		),
+	})
+
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+	p := &fakeProgress{
+		t:                   t,
+		expectedFiles:       0,
+		expectedDirectories: 2,
+		expectedErrors:      0,
+	}
+
+	err := Estimate(context.TODO(), nil, rootDir, policyTree, p, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/snapshot/snapshotfs/repofs.go
+++ b/snapshot/snapshotfs/repofs.go
@@ -113,6 +113,10 @@ func (rd *repositoryDirectory) Summary(ctx context.Context) (*fs.DirectorySummar
 	return rd.summary, nil
 }
 
+func (rd *repositoryDirectory) MultipleIterations() bool {
+	return true
+}
+
 func (rd *repositoryDirectory) Child(ctx context.Context, name string) (fs.Entry, error) {
 	if err := rd.ensureDirEntriesLoaded(ctx); err != nil {
 		return nil, err

--- a/snapshot/snapshotfs/source_directories.go
+++ b/snapshot/snapshotfs/source_directories.go
@@ -57,6 +57,10 @@ func (s *sourceDirectories) LocalFilesystemPath() string {
 	return ""
 }
 
+func (s *sourceDirectories) MultipleIterations() bool {
+	return true
+}
+
 func (s *sourceDirectories) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)

--- a/snapshot/snapshotfs/source_snapshots.go
+++ b/snapshot/snapshotfs/source_snapshots.go
@@ -55,6 +55,10 @@ func (s *sourceSnapshots) LocalFilesystemPath() string {
 	return ""
 }
 
+func (s *sourceSnapshots) MultipleIterations() bool {
+	return true
+}
+
 func (s *sourceSnapshots) Child(ctx context.Context, name string) (fs.Entry, error) {
 	// nolint:wrapcheck
 	return fs.IterateEntriesAndFindChild(ctx, s, name)

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -711,11 +711,11 @@ func TestUpload_StreamingDirectory(t *testing.T) {
 
 			policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
 
-			files := fs.Entries{
+			files := []fs.Entry{
 				mockfs.NewFile("f1", []byte{1, 2, 3}, defaultPermissions),
 			}
 
-			staticRoot := virtualfs.NewStaticDirectory("rootdir", fs.Entries{
+			staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
 				virtualfs.NewStreamingDirectory(
 					"stream-directory",
 					func(innerCtx context.Context, callback func(context.Context, fs.Entry) error) error {
@@ -776,12 +776,12 @@ func TestUpload_StreamingDirectoryWithIgnoredFile(t *testing.T) {
 		},
 	}, policy.DefaultPolicy)
 
-	files := fs.Entries{
+	files := []fs.Entry{
 		mockfs.NewFile("f1", []byte{1, 2, 3}, defaultPermissions),
 		mockfs.NewFile("f2", []byte{1, 2, 3, 4}, defaultPermissions),
 	}
 
-	staticRoot := virtualfs.NewStaticDirectory("rootdir", fs.Entries{
+	staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
 		virtualfs.NewStreamingDirectory(
 			"stream-directory",
 			func(innerCtx context.Context, callback func(context.Context, fs.Entry) error) error {

--- a/snapshot/snapshotfs/upload_test.go
+++ b/snapshot/snapshotfs/upload_test.go
@@ -693,68 +693,58 @@ func TestUpload_VirtualDirectoryWithStreamingFile(t *testing.T) {
 }
 
 func TestUpload_StreamingDirectory(t *testing.T) {
-	cases := map[string]bool{
-		"MultipleIterations": true,
-		"SingleIteration":    false,
+	ctx := testlogging.Context(t)
+	th := newUploadTestHarness(ctx, t)
+
+	defer th.cleanup()
+
+	t.Logf("Uploading streaming directory with mock file")
+
+	u := NewUploader(th.repo)
+
+	policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+
+	files := []fs.Entry{
+		mockfs.NewFile("f1", []byte{1, 2, 3}, defaultPermissions),
 	}
 
-	for desc, iterations := range cases {
-		t.Run(desc, func(t *testing.T) {
-			ctx := testlogging.Context(t)
-			th := newUploadTestHarness(ctx, t)
+	staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
+		virtualfs.NewStreamingDirectory(
+			"stream-directory",
+			func(innerCtx context.Context, callback func(context.Context, fs.Entry) error) error {
+				for _, f := range files {
+					if err := callback(innerCtx, f); err != nil {
+						return err
+					}
+				}
 
-			defer th.cleanup()
+				return nil
+			},
+		),
+	})
 
-			t.Logf("Uploading streaming directory with mock file")
+	man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
+	if err != nil {
+		t.Fatalf("Upload error: %v", err)
+	}
 
-			u := NewUploader(th.repo)
+	if got, want := atomic.LoadInt32(&man.Stats.CachedFiles), int32(0); got != want {
+		t.Errorf("unexpected manifest cached files: %v, want %v", got, want)
+	}
 
-			policyTree := policy.BuildTree(nil, policy.DefaultPolicy)
+	if got, want := atomic.LoadInt32(&man.Stats.NonCachedFiles), int32(1); got != want {
+		// one file is not cached
+		t.Errorf("unexpected manifest non-cached files: %v, want %v", got, want)
+	}
 
-			files := []fs.Entry{
-				mockfs.NewFile("f1", []byte{1, 2, 3}, defaultPermissions),
-			}
+	if got, want := atomic.LoadInt32(&man.Stats.TotalDirectoryCount), int32(2); got != want {
+		// must have one directory
+		t.Errorf("unexpected manifest directory count: %v, want %v", got, want)
+	}
 
-			staticRoot := virtualfs.NewStaticDirectory("rootdir", []fs.Entry{
-				virtualfs.NewStreamingDirectory(
-					"stream-directory",
-					func(innerCtx context.Context, callback func(context.Context, fs.Entry) error) error {
-						for _, f := range files {
-							if err := callback(innerCtx, f); err != nil {
-								return err
-							}
-						}
-
-						return nil
-					},
-					iterations,
-				),
-			})
-
-			man, err := u.Upload(ctx, staticRoot, policyTree, snapshot.SourceInfo{})
-			if err != nil {
-				t.Fatalf("Upload error: %v", err)
-			}
-
-			if got, want := atomic.LoadInt32(&man.Stats.CachedFiles), int32(0); got != want {
-				t.Fatalf("unexpected manifest cached files: %v, want %v", got, want)
-			}
-
-			if got, want := atomic.LoadInt32(&man.Stats.NonCachedFiles), int32(1); got != want {
-				// one file is not cached
-				t.Fatalf("unexpected manifest non-cached files: %v, want %v", got, want)
-			}
-
-			if got, want := atomic.LoadInt32(&man.Stats.TotalDirectoryCount), int32(2); got != want {
-				// must have one directory
-				t.Fatalf("unexpected manifest directory count: %v, want %v", got, want)
-			}
-
-			if got, want := atomic.LoadInt32(&man.Stats.TotalFileCount), int32(1); got != want {
-				// must have one file
-				t.Fatalf("unexpected manifest file count: %v, want %v", got, want)
-			}
-		})
+	if got, want := atomic.LoadInt32(&man.Stats.TotalFileCount), int32(1); got != want {
+		// must have one file
+		t.Errorf("unexpected manifest file count: %v, want %v", got, want)
 	}
 }
 
@@ -793,7 +783,6 @@ func TestUpload_StreamingDirectoryWithIgnoredFile(t *testing.T) {
 
 				return nil
 			},
-			true,
 		),
 	})
 
@@ -803,22 +792,22 @@ func TestUpload_StreamingDirectoryWithIgnoredFile(t *testing.T) {
 	}
 
 	if got, want := atomic.LoadInt32(&man.Stats.CachedFiles), int32(0); got != want {
-		t.Fatalf("unexpected manifest cached files: %v, want %v", got, want)
+		t.Errorf("unexpected manifest cached files: %v, want %v", got, want)
 	}
 
 	if got, want := atomic.LoadInt32(&man.Stats.NonCachedFiles), int32(1); got != want {
 		// one file is not cached
-		t.Fatalf("unexpected manifest non-cached files: %v, want %v", got, want)
+		t.Errorf("unexpected manifest non-cached files: %v, want %v", got, want)
 	}
 
 	if got, want := atomic.LoadInt32(&man.Stats.TotalDirectoryCount), int32(2); got != want {
 		// must have one directory
-		t.Fatalf("unexpected manifest directory count: %v, want %v", got, want)
+		t.Errorf("unexpected manifest directory count: %v, want %v", got, want)
 	}
 
 	if got, want := atomic.LoadInt32(&man.Stats.TotalFileCount), int32(1); got != want {
 		// must have one file
-		t.Fatalf("unexpected manifest file count: %v, want %v", got, want)
+		t.Errorf("unexpected manifest file count: %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Recently PR-ed upstream, but has not yet been reviewed anywhere

Creates the `virtualfs.StreamingDirectory` type that allows one to dynamically add directory entries. Also create an escape hatch to state the directory is one-time-use for getting entries so users can avoid concurrency/efficiency problems during streaming