### PR TITLE
Allow configuring auto compaction count

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -228,7 +228,7 @@ func (m *committedManifestManager) compact(ctx context.Context) error {
 func (m *committedManifestManager) maybeCompactLocked(ctx context.Context) error {
 	m.verifyLocked()
 
-	if len(m.committedContentIDs) < autoCompactionContentCount {
+	if len(m.committedContentIDs) < getAutoCompactionContentCount() {
 		return nil
 	}
 

--- a/repo/manifest/manifest_manager.go
+++ b/repo/manifest/manifest_manager.go
@@ -6,7 +6,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -32,9 +34,22 @@ var ErrNotFound = errors.New("not found")
 
 // ContentPrefix is the prefix of the content id for manifests.
 const (
-	ContentPrefix              = "m"
-	autoCompactionContentCount = 16
+	ContentPrefix                     = "m"
+	autoCompactionContentCountDefault = 16
+	autoCompactionEnvKey              = "KOPIA_MANIFEST_AUTOCOMPACT_COUNT"
 )
+
+// getAutoCompactionContentCount returns the content count after which
+// auto compaction should kick in
+func getAutoCompactionContentCount() int {
+	retVal := autoCompactionContentCountDefault
+	if v := os.Getenv(autoCompactionEnvKey); v != "" {
+		if vint, err := strconv.Atoi(v); err == nil {
+			retVal = vint
+		}
+	}
+	return retVal
+}
 
 // TypeLabelKey is the label key for manifest type.
 const TypeLabelKey = "type"

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -380,4 +381,64 @@ func TestManifestAutoCompaction(t *testing.T) {
 		require.NoError(t, mgr.Flush(ctx))
 		require.NoError(t, mgr.b.Flush(ctx))
 	}
+}
+
+func TestManifestConfigureAutoCompaction(t *testing.T) {
+	ctx := testlogging.Context(t)
+	data := blobtesting.DataMap{}
+	item1 := map[string]int{"foo": 1, "bar": 2}
+	labels1 := map[string]string{"type": "item", "color": "red"}
+
+	mgr := newManagerForTesting(ctx, t, data)
+
+	compactionCount := 99
+
+	t.Setenv(autoCompactionEnvKey, strconv.Itoa(compactionCount))
+
+	for i := 0; i < compactionCount-1; i++ {
+		addAndVerify(ctx, t, mgr, labels1, item1)
+		require.NoError(t, mgr.Flush(ctx))
+		require.NoError(t, mgr.b.Flush(ctx))
+	}
+
+	// Should not trigger compaction
+	_, err := mgr.Find(ctx, labels1)
+	require.NoError(t, err)
+
+	foundContents := getManifestContentCount(ctx, t, mgr)
+
+	if got, want := foundContents, compactionCount-1; got != want {
+		t.Errorf("unexpected number of blocks: %v, want %v", got, want)
+	}
+
+	// Add another manifest
+	addAndVerify(ctx, t, mgr, labels1, item1)
+
+	require.NoError(t, mgr.Flush(ctx))
+	require.NoError(t, mgr.b.Flush(ctx))
+
+	// *Should* trigger compaction
+	_, err = mgr.Find(ctx, labels1)
+	require.NoError(t, err)
+
+	foundContents = getManifestContentCount(ctx, t, mgr)
+
+	if got, want := foundContents, 1; got != want {
+		t.Errorf("unexpected number of blocks: %v, want %v", got, want)
+	}
+
+}
+
+func getManifestContentCount(ctx context.Context, t *testing.T, mgr *Manager) int {
+	foundContents := 0
+	if err := mgr.b.IterateContents(
+		ctx,
+		content.IterateOptions{Range: index.PrefixRange(ContentPrefix)},
+		func(ci content.Info) error {
+			foundContents++
+			return nil
+		}); err != nil {
+		t.Errorf("unable to list manifest content: %v", err)
+	}
+	return foundContents
 }


### PR DESCRIPTION
This introduces an environment variable to configure manifest auto compaction.

Once this approach is validated - we can follow up with a PR upstream with the environment variable or by plumbing this via repository connect options.
