### PR TITLE
Stream loading of manifests instead of loading them all and then deduplicating

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -161,11 +161,13 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 				ci.ContentID,
 				func(e *manifestEntry) bool {
 					mu.Lock()
-					defer mu.Unlock()
-
 					prev := committedEntries[e.ID]
+					mu.Unlock()
+
 					if prev == nil || e.ModTime.After(prev.ModTime) {
+						mu.Lock()
 						committedEntries[e.ID] = e
+						mu.Unlock()
 					}
 
 					// Continue iteration.

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -137,20 +137,43 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 	m.verifyLocked()
 
 	var (
-		mu        sync.Mutex
-		manifests map[content.ID]manifest
+		mu sync.Mutex
+
+		// Temporary set of mappings that we can swap with what's currently in the
+		// manager once we're done. This ensures we don't clobber existing data if
+		// we fail to load manifests.
+		committedEntries    = map[ID]*manifestEntry{}
+		committedContentIDs = map[content.ID]bool{}
 	)
 
 	for {
-		manifests = map[content.ID]manifest{}
-
 		err := m.b.IterateContents(ctx, content.IterateOptions{
 			Range:    index.PrefixRange(ContentPrefix),
 			Parallel: manifestLoadParallelism,
 		}, func(ci content.Info) error {
-			man, err := loadManifestContent(ctx, m.b, ci.GetContentID())
+			mu.Lock()
+			committedContentIDs[ci.ContentID] = true
+			mu.Unlock()
+
+			err := forEachManifestEntry(
+				ctx,
+				m.b,
+				ci.ContentID,
+				func(e *manifestEntry) bool {
+					mu.Lock()
+					defer mu.Unlock()
+
+					prev := committedEntries[e.ID]
+					if prev == nil || e.ModTime.After(prev.ModTime) {
+						committedEntries[e.ID] = e
+					}
+
+					// Continue iteration.
+					return true
+				},
+			)
 			if err != nil {
-				// this can be used to allow corrupterd repositories to still open and see the
+				// this can be used to allow corrupted repositories to still open and see the
 				// (incomplete) list of manifests.
 				if os.Getenv("KOPIA_IGNORE_MALFORMED_MANIFEST_CONTENTS") != "" {
 					log(ctx).Warnf("ignoring malformed manifest content %v: %v", ci.GetContentID(), err)
@@ -160,9 +183,6 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 
 				return err
 			}
-			mu.Lock()
-			manifests[ci.GetContentID()] = man
-			mu.Unlock()
 			return nil
 		})
 		if err == nil {
@@ -178,7 +198,17 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 		return errors.Wrap(err, "unable to load manifest contents")
 	}
 
-	m.loadManifestContentsLocked(manifests)
+	// Remove deleted manifests from the new list. We have to do this last because
+	// removing entries from the list while loading would lose mod time info
+	// that's used to determine if a tombstone is newer than a populated entry.
+	for id, e := range committedEntries {
+		if e.Deleted {
+			delete(committedEntries, id)
+		}
+	}
+
+	m.committedEntries = committedEntries
+	m.committedContentIDs = committedContentIDs
 
 	if err := m.maybeCompactLocked(ctx); err != nil {
 		return errors.Wrap(err, "error auto-compacting contents")
@@ -188,6 +218,8 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 }
 
 // +checklocks:m.cmmu
+//
+//nolint:unused
 func (m *committedManifestManager) loadManifestContentsLocked(manifests map[content.ID]manifest) {
 	m.committedEntries = map[ID]*manifestEntry{}
 	m.committedContentIDs = map[content.ID]bool{}
@@ -283,6 +315,8 @@ func (m *committedManifestManager) compactLocked(ctx context.Context) error {
 }
 
 // +checklocks:m.cmmu
+//
+//nolint:unused
 func (m *committedManifestManager) mergeEntryLocked(e *manifestEntry) {
 	m.verifyLocked()
 
@@ -340,6 +374,7 @@ func (m *committedManifestManager) verifyLocked() {
 	}
 }
 
+//nolint:unused
 func loadManifestContent(ctx context.Context, b contentManager, contentID content.ID) (manifest, error) {
 	man := manifest{}
 

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -217,31 +217,6 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 	return nil
 }
 
-// +checklocks:m.cmmu
-//
-//nolint:unused
-func (m *committedManifestManager) loadManifestContentsLocked(manifests map[content.ID]manifest) {
-	m.committedEntries = map[ID]*manifestEntry{}
-	m.committedContentIDs = map[content.ID]bool{}
-
-	for contentID := range manifests {
-		m.committedContentIDs[contentID] = true
-	}
-
-	for _, man := range manifests {
-		for _, e := range man.Entries {
-			m.mergeEntryLocked(e)
-		}
-	}
-
-	// after merging, remove contents marked as deleted.
-	for k, e := range m.committedEntries {
-		if e.Deleted {
-			delete(m.committedEntries, k)
-		}
-	}
-}
-
 func (m *committedManifestManager) compact(ctx context.Context) error {
 	m.lock()
 	defer m.unlock()
@@ -315,23 +290,6 @@ func (m *committedManifestManager) compactLocked(ctx context.Context) error {
 }
 
 // +checklocks:m.cmmu
-//
-//nolint:unused
-func (m *committedManifestManager) mergeEntryLocked(e *manifestEntry) {
-	m.verifyLocked()
-
-	prev := m.committedEntries[e.ID]
-	if prev == nil {
-		m.committedEntries[e.ID] = e
-		return
-	}
-
-	if e.ModTime.After(prev.ModTime) {
-		m.committedEntries[e.ID] = e
-	}
-}
-
-// +checklocks:m.cmmu
 func (m *committedManifestManager) ensureInitializedLocked(ctx context.Context) error {
 	rev := m.b.Revision()
 	if m.lastRevision == rev {
@@ -372,29 +330,6 @@ func (m *committedManifestManager) verifyLocked() {
 	if !m.locked {
 		panic("not locked")
 	}
-}
-
-//nolint:unused
-func loadManifestContent(ctx context.Context, b contentManager, contentID content.ID) (manifest, error) {
-	man := manifest{}
-
-	blk, err := b.GetContent(ctx, contentID)
-	if err != nil {
-		return man, errors.Wrap(err, "error loading manifest content")
-	}
-
-	gz, err := gzip.NewReader(bytes.NewReader(blk))
-	if err != nil {
-		return man, errors.Wrapf(err, "unable to unpack manifest data %q", contentID)
-	}
-
-	// Will be GC-ed even if we don't close it?
-	//nolint:errcheck
-	defer gz.Close()
-
-	man, err = decodeManifestArray(gz)
-
-	return man, errors.Wrapf(err, "unable to parse manifest %q", contentID)
 }
 
 // forEachManifestEntry loads the content piece with manifests and calls the

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -362,6 +362,38 @@ func loadManifestContent(ctx context.Context, b contentManager, contentID conten
 	return man, errors.Wrapf(err, "unable to parse manifest %q", contentID)
 }
 
+// forEachManifestEntry loads the content piece with manifests and calls the
+// callback for each manifestEntry. If the callback returns false then it stops
+// loading manifests and returns. In cases where the callback returns false,
+// content with invalid formatting may not return parse errors.
+func forEachManifestEntry(
+	ctx context.Context,
+	b contentManager,
+	contentID content.ID,
+	callback func(e *manifestEntry) bool,
+) error {
+	blk, err := b.GetContent(ctx, contentID)
+	if err != nil {
+		return errors.Wrapf(err, "error loading manifest content %q", contentID)
+	}
+
+	gz, err := gzip.NewReader(bytes.NewReader(blk))
+	if err != nil {
+		return errors.Wrapf(err, "unable to unpack manifest data %q", contentID)
+	}
+
+	// Will be GC-ed even if we don't close it?
+	//nolint:errcheck
+	defer gz.Close()
+
+	err = forEachDeserializedEntry(gz, callback)
+	if err != nil {
+		return errors.Wrapf(err, "unable to iterate manifests in content %q", contentID)
+	}
+
+	return nil
+}
+
 func newCommittedManager(b contentManager, autoCompactionThreshold int) *committedManifestManager {
 	debugID := ""
 	if os.Getenv("KOPIA_DEBUG_MANIFEST_MANAGER") != "" {

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -152,13 +152,13 @@ func (m *committedManifestManager) loadCommittedContentsLocked(ctx context.Conte
 			Parallel: manifestLoadParallelism,
 		}, func(ci content.Info) error {
 			mu.Lock()
-			committedContentIDs[ci.ContentID] = true
+			committedContentIDs[ci.GetContentID()] = true
 			mu.Unlock()
 
 			err := forEachManifestEntry(
 				ctx,
 				m.b,
-				ci.ContentID,
+				ci.GetContentID(),
 				func(e *manifestEntry) bool {
 					mu.Lock()
 					prev := committedEntries[e.ID]

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -3,10 +3,12 @@ package manifest
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -313,8 +315,8 @@ type contentManagerOpts struct {
 	readOnly bool
 }
 
-func newContentManagerForTesting(ctx context.Context, t *testing.T, data blobtesting.DataMap, opts contentManagerOpts) contentManager {
-	t.Helper()
+func newContentManagerForTesting(ctx context.Context, tb testing.TB, data blobtesting.DataMap, opts contentManagerOpts) contentManager {
+	tb.Helper()
 
 	st := blobtesting.NewMapStorage(data, nil, nil)
 
@@ -331,12 +333,12 @@ func newContentManagerForTesting(ctx context.Context, t *testing.T, data blobtes
 		},
 	}, nil)
 
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
 	bm, err := content.NewManagerForTesting(ctx, st, fop, nil, nil)
-	require.NoError(t, err)
+	require.NoError(tb, err)
 
-	t.Cleanup(func() { bm.CloseShared(ctx) })
+	tb.Cleanup(func() { bm.CloseShared(ctx) })
 
 	return bm
 }
@@ -479,8 +481,8 @@ func TestManifestConfigureAutoCompaction(t *testing.T) {
 	}
 }
 
-func getManifestContentCount(ctx context.Context, t *testing.T, mgr *Manager) int {
-	t.Helper()
+func getManifestContentCount(ctx context.Context, tb testing.TB, mgr *Manager) int {
+	tb.Helper()
 
 	foundContents := 0
 
@@ -491,8 +493,109 @@ func getManifestContentCount(ctx context.Context, t *testing.T, mgr *Manager) in
 			foundContents++
 			return nil
 		}); err != nil {
-		t.Errorf("unable to list manifest content: %v", err)
+		tb.Errorf("unable to list manifest content: %v", err)
 	}
 
 	return foundContents
+}
+
+// BenchmarkConcurrentCompactionLoading benchmarks the runtime of loading
+// multiple content pieces containing manifests that are all duplicates of each
+// other. Situations like this can arise when clients concurrently compact
+// manifests.
+func BenchmarkConcurrentCompactionLoading(b *testing.B) {
+	ctx := testlogging.Context(b)
+	data := blobtesting.DataMap{}
+
+	bm := newContentManagerForTesting(ctx, b, data, contentManagerOpts{})
+
+	// Setup a manifest manager with a bunch of manifests of non-trivial size.
+	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
+	require.NoError(b, err, "getting initial manifest manager")
+
+	// Manifest content will be ~1K when serialized.
+	manifestData := map[string]string{}
+	for i := range 64 {
+		str := fmt.Sprintf("%016d", i)
+		manifestData[str] = str
+	}
+
+	labels := map[string]string{"type": "item", "color": "red"}
+
+	for range 100 {
+		_, err = mgr.Put(ctx, labels, manifestData)
+		require.NoError(b, err, "adding item to manifest manager")
+
+		require.NoError(b, mgr.Flush(ctx))
+		require.NoError(b, mgr.b.Flush(ctx))
+	}
+
+	assert.Equal(
+		b,
+		100,
+		getManifestContentCount(ctx, b, mgr),
+		"expected number of content pieces",
+	)
+
+	// Open several other manifest mangers that will concurrently compact the set
+	// of manifests added above.
+	var (
+		wg sync.WaitGroup
+		c  = make(chan struct{})
+	)
+
+	for range 5 {
+		wg.Add(1)
+
+		// Use only asserts below to avoid calling require in goroutines.
+		go func() {
+			defer wg.Done()
+
+			<-c
+
+			mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
+			assert.NoError(b, err, "getting compaction instance of manifest manager")
+
+			entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
+			assert.NoError(b, err, "forcing reload of manifest manager")
+			assert.Len(b, entries, 100)
+		}()
+	}
+
+	close(c)
+
+	wg.Wait()
+
+	// If the above compaction attempts failed the benchmark then exit early.
+	if b.Failed() {
+		return
+	}
+
+	// Just log the number of compacted manifests since we can't guarantee they'll
+	// all run compaction due to race conditions.
+	b.Logf(
+		"have %d compacted manifest content pieces",
+		getManifestContentCount(ctx, b, mgr),
+	)
+
+	// Configure things for read-only mode since we don't care about compaction
+	// anymore.
+	bm = newContentManagerForTesting(
+		ctx,
+		b,
+		data,
+		contentManagerOpts{readOnly: true},
+	)
+
+	// Run the actual benchmark with the current setup.
+	b.ResetTimer()
+
+	for range b.N {
+		mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
+		require.NoError(b, err, "getting benchmark instance of manifest manager")
+
+		entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
+		require.NoError(b, err, "forcing reload of manifest manager")
+		assert.Len(b, entries, 100)
+	}
 }

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -413,7 +413,7 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err, "getting initial manifest manager")
 
-	for range 100 {
+	for i := 0; i < 100; i++ {
 		item1 := map[string]int{"foo": 1, "bar": 2}
 		labels1 := map[string]string{"type": "item", "color": "red"}
 
@@ -515,14 +515,15 @@ func BenchmarkConcurrentCompactionLoading(b *testing.B) {
 
 	// Manifest content will be ~1K when serialized.
 	manifestData := map[string]string{}
-	for i := range 64 {
+
+	for i := 0; i < 64; i++ {
 		str := fmt.Sprintf("%016d", i)
 		manifestData[str] = str
 	}
 
 	labels := map[string]string{"type": "item", "color": "red"}
 
-	for range 100 {
+	for i := 0; i < 100; i++ {
 		_, err = mgr.Put(ctx, labels, manifestData)
 		require.NoError(b, err, "adding item to manifest manager")
 
@@ -544,7 +545,7 @@ func BenchmarkConcurrentCompactionLoading(b *testing.B) {
 		c  = make(chan struct{})
 	)
 
-	for range 5 {
+	for i := 0; i < 5; i++ {
 		wg.Add(1)
 
 		// Use only asserts below to avoid calling require in goroutines.
@@ -553,11 +554,11 @@ func BenchmarkConcurrentCompactionLoading(b *testing.B) {
 
 			<-c
 
-			mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
-			assert.NoError(b, err, "getting compaction instance of manifest manager")
+			compactionMgr, innerErr := NewManager(ctx, bm, ManagerOptions{}, nil)
+			assert.NoError(b, innerErr, "getting compaction instance of manifest manager")
 
-			entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
-			assert.NoError(b, err, "forcing reload of manifest manager")
+			entries, innerErr := compactionMgr.Find(ctx, map[string]string{"color": "red"})
+			assert.NoError(b, innerErr, "forcing reload of manifest manager")
 			assert.Len(b, entries, 100)
 		}()
 	}
@@ -590,7 +591,7 @@ func BenchmarkConcurrentCompactionLoading(b *testing.B) {
 	// Run the actual benchmark with the current setup.
 	b.ResetTimer()
 
-	for range b.N {
+	for i := 0; i < b.N; i++ {
 		mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
 		require.NoError(b, err, "getting benchmark instance of manifest manager")
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -411,7 +411,7 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	mgr, err := NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err, "getting initial manifest manager")
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		item1 := map[string]int{"foo": 1, "bar": 2}
 		labels1 := map[string]string{"type": "item", "color": "red"}
 
@@ -429,8 +429,9 @@ func TestManifestAutoCompactionWithReadOnly(t *testing.T) {
 	mgr, err = NewManager(ctx, bm, ManagerOptions{}, nil)
 	require.NoError(t, err, "getting other instance of manifest manager")
 
-	_, err = mgr.Find(ctx, map[string]string{"color": "red"})
-	assert.NoError(t, err, "forcing reload of manifest manager")
+	entries, err := mgr.Find(ctx, map[string]string{"color": "red"})
+	require.NoError(t, err, "forcing reload of manifest manager")
+	assert.Len(t, entries, 100)
 }
 
 func TestManifestConfigureAutoCompaction(t *testing.T) {

--- a/repo/manifest/serialized.go
+++ b/repo/manifest/serialized.go
@@ -64,39 +64,6 @@ func stringToken(dec *json.Decoder) (string, error) {
 	return l, nil
 }
 
-func decodeManifestArray(r io.Reader) (manifest, error) {
-	var (
-		dec = json.NewDecoder(r)
-		res = manifest{}
-	)
-
-	if err := expectDelimToken(dec, objectOpen); err != nil {
-		return res, err
-	}
-
-	// Need to manually decode fields here since we can't reuse the stdlib
-	// decoder due to memory issues.
-	allProcessed, err := parseFields(
-		dec,
-		func(e *manifestEntry) bool {
-			res.Entries = append(res.Entries, e)
-			return true
-		},
-	)
-	if err != nil {
-		return res, err
-	}
-
-	if !allProcessed {
-		return res, errors.New("didn't see all entries for serialized manifest")
-	}
-
-	// Consumes closing object curly brace after we're done. Don't need to check
-	// for EOF because json.Decode only guarantees decoding the next JSON item in
-	// the stream so this follows that.
-	return res, expectDelimToken(dec, objectClose)
-}
-
 // forEachDeserializedEntry deserializes json data from the provided reader and
 // calls the provided callback for each *manifestEntry. Note that the callback
 // may be called on entries even if an error is later encountered while

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -3,6 +3,7 @@ package manifest
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +13,20 @@ import (
 
 	"github.com/kopia/kopia/repo/manifest/testdata"
 )
+
+func decodeManifestArray(r io.Reader) (manifest, error) {
+	var res manifest
+
+	err := forEachDeserializedEntry(
+		r,
+		func(e *manifestEntry) bool {
+			res.Entries = append(res.Entries, e)
+			return true
+		},
+	)
+
+	return res, err
+}
 
 func TestManifestDecode_GoodInput(t *testing.T) {
 	table := []struct {

--- a/repo/manifest/serialized_test.go
+++ b/repo/manifest/serialized_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,91 @@ func TestManifestDecode_BadInput(t *testing.T) {
 			t.Logf("%v", err)
 
 			assert.Error(t, err)
+		})
+	}
+}
+
+func TestManifestDecode_StopEarly(t *testing.T) {
+	table := []struct {
+		name        string
+		input       string
+		expectEntry *manifestEntry
+		expectErr   bool
+	}{
+		{
+			name:  "EntryFoundLast_CompleteObject",
+			input: `{"entries":[{"id":"efg"},{"id":"abcd"}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryFoundFirst_CompleteObject",
+			input: `{"entries":[{"id":"abcd"},{"id":"efg"}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryFound_FirstInstanceWins",
+			input: `{"entries":[{"id":"abcd"},{"id":"abcd","deleted":true}]}`,
+			expectEntry: &manifestEntry{
+				ID: "abcd",
+			},
+		},
+		{
+			name:  "EntryNotFound_CompleteObject",
+			input: `{"entries":[{"id":"abcde"},{"id":"efg","deleted":true}]}`,
+		},
+		{
+			name:  "EntryNotFound_CompleteObjectWithOtherFields",
+			input: `{"foo":"bar"}`,
+		},
+		{
+			name:  "EntryNotFound_CompleteObjectNoEntries",
+			input: `{}`,
+		},
+		{
+			name:      "EntryNotFound_IncompleteObject",
+			input:     `{"foo":"bar"`,
+			expectErr: true,
+		},
+		{
+			name:      "EntryNotFound_IncompleteObject",
+			input:     `{"entries":[{"id":"abcde"},{"id":"efg","deleted":true}]`,
+			expectErr: true,
+		},
+		{
+			name:      "EntryFoundLast_IncompleteObject",
+			input:     `{"entries":[{"id":"efg",{"id":"abcd"}]}`,
+			expectErr: true,
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			var found *manifestEntry
+
+			r := strings.NewReader(test.input)
+			err := forEachDeserializedEntry(
+				r,
+				func(e *manifestEntry) bool {
+					if e.ID == "abcd" {
+						found = e
+						return false
+					}
+
+					return true
+				},
+			)
+
+			assert.Equal(t, test.expectEntry, found)
+
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Save some memory if concurrent manifest compaction happens by deduplicating manifests one by one instead of loading all manifests and then deduplicating them. This also has some building blocks that will be useful in later PRs in which we drop manifest contents, keeping only the metadata, and lazily reload manifest contents as needed

This PR does slightly change the semantics for deserializing JSON (i.e. it's now possible to not get deserialization errors when we normally would as in this [set of tests](https://github.com/alcionai/kopia/pull/375/files#diff-bf358d9210245d046513421514af0bb57cfb49e37eb84ef4ca8acf8b3ee75bf2R85)), but given loading manifests still attempts to load all `manifestEntry`s in a content piece we should still see the parse errors if there are any