### PR TITLE
Allow controlling max manifests per content with env var

### DIFF
--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -158,11 +158,6 @@ func (m *committedManifestManager) writeEntriesLocked(
 
 		// Still write all entries out in a single content piece if we're not
 		// compacting things.
-		//
-		// Even if the result of getMaxManifestsPer content is 0 or negative, we'll
-		// still make progress because this is a less-than check. At worst, if
-		// there's a configuration that asks for a negative or zero manifests per
-		// content piece then we'll write out each manifest individually.
 		if !isCompaction ||
 			maxPerContent <= 0 ||
 			int64(len(man.Entries)) < maxPerContent {

--- a/repo/manifest/committed_manifest_manager.go
+++ b/repo/manifest/committed_manifest_manager.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultMaxManifestsPerContent = 1000000
+	defaultMaxManifestsPerContent = 100000
 	maxManifestsPerContentEnvKey  = "KOPIA_MAX_MANIFESTS_PER_CONTENT_COUNT"
 )
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -557,6 +557,13 @@ func TestCompactManyManifests(t *testing.T) {
 			otherManifests:   3,
 			expectContents:   6,
 		},
+		{
+			name:             "EnvLargerThanNumManifests",
+			envFlag:          "500",
+			initialManifests: 3,
+			otherManifests:   3,
+			expectContents:   1,
+		},
 	}
 
 	for _, test := range table {

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -591,6 +592,8 @@ func TestCompactManyManifests(t *testing.T) {
 		},
 	}
 
+	t.Setenv(maxManifestsPerContentEnvKey, "")
+
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := testlogging.Context(t)
@@ -599,6 +602,10 @@ func TestCompactManyManifests(t *testing.T) {
 			labels1 := map[string]string{"type": "item", "color": "red"}
 
 			t.Setenv(maxManifestsPerContentEnvKey, test.envFlag)
+
+			if test.unsetEnvFlag {
+				os.Unsetenv(maxManifestsPerContentEnvKey)
+			}
 
 			mgr := newManagerForTesting(ctx, t, data, ManagerOptions{})
 

--- a/repo/manifest/manifest_manager_test.go
+++ b/repo/manifest/manifest_manager_test.go
@@ -569,6 +569,20 @@ func TestCompactManyManifests(t *testing.T) {
 			expectContents:   2,
 		},
 		{
+			name:             "ExactlyAtEnvValue",
+			envFlag:          "100",
+			initialManifests: 94,
+			otherManifests:   6,
+			expectContents:   1,
+		},
+		{
+			name:             "ExactlyDoubleEnvValue",
+			envFlag:          "100",
+			initialManifests: 194,
+			otherManifests:   6,
+			expectContents:   2,
+		},
+		{
 			name:             "LessManifestsThanEnvValue",
 			envFlag:          "500",
 			initialManifests: 5,


### PR DESCRIPTION
Allow adjustments to the max number of manifests per content piece through the use of an environment variable